### PR TITLE
feat: add test example

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,31 +2,34 @@ name: CI
 
 on:
   push:
-    branches: [ main, master ]
+    branches:
+      - main
+      - master
+      - feature/*
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - uses: actions/setup-node@v2
-      with:
-        node-version: '16.x'
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
 
-    - uses: actions/cache@v2
-      id: yarn-cache
-      with:
-        path: |
-          **/node_modules
-          **/.eslintcache
-          ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: |
+            **/node_modules
+            **/.eslintcache
+            ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
-    - name: Install modules
-      run: yarn install --frozen-lockfile
+      - name: Install modules
+        run: yarn install --frozen-lockfile
 
-    - name: Run tests
-      run: yarn test
+      - name: Run tests
+        run: yarn test

--- a/packages/compiler-pico-c/src/arch/x86/asm-utils/genDefConst.ts
+++ b/packages/compiler-pico-c/src/arch/x86/asm-utils/genDefConst.ts
@@ -1,5 +1,5 @@
 type DefConstType = 'db' | 'dw' | 'dd' | 'dq' | 'dt';
 
 export function genDefConst(type: DefConstType, values: number[]): string {
-  return `${type} ${values.join(', ')}`;
+  return `${type} ${values.map(val => val ?? 0x0).join(', ')}`;
 }

--- a/packages/compiler-pico-c/src/arch/x86/asm-utils/genLabel.ts
+++ b/packages/compiler-pico-c/src/arch/x86/asm-utils/genLabel.ts
@@ -9,7 +9,7 @@ export function genLabelName(name: string): string {
  *  Move it to compiler context! Compiler should generate unique
  *  label prefix per compilation unit!
  */
-export function genLabel(name: string, prefix?: boolean): string {
+export function genLabel(name: string, prefix: boolean = true): string {
   const inner = prefix ? genLabelName(name) : name;
 
   return `${inner}:`;

--- a/packages/compiler-pico-c/src/arch/x86/asm-utils/genLabel.ts
+++ b/packages/compiler-pico-c/src/arch/x86/asm-utils/genLabel.ts
@@ -4,6 +4,13 @@ export function genLabelName(name: string): string {
   return `${DEFAULT_UNIQ_PREFIX}${name.replace(/[{}]/g, '_')}`;
 }
 
-export function genLabel(name: string): string {
-  return `${genLabelName(name)}:`;
+/**
+ * @todo
+ *  Move it to compiler context! Compiler should generate unique
+ *  label prefix per compilation unit!
+ */
+export function genLabel(name: string, prefix?: boolean): string {
+  const inner = prefix ? genLabelName(name) : name;
+
+  return `${inner}:`;
 }

--- a/packages/compiler-pico-c/src/arch/x86/backend/X86Allocator.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/X86Allocator.ts
@@ -6,6 +6,8 @@ import { X86StackFrame } from './X86StackFrame';
 import { X86BasicRegAllocator } from './reg-allocator';
 import { genInstruction, genLabelName } from '../asm-utils';
 
+export type X86StackFrameContentFn = () => { asm: string[]; ret: string[] };
+
 export class X86Allocator {
   private readonly labels: { [id: string]: string } = {};
 
@@ -48,20 +50,24 @@ export class X86Allocator {
   /**
    * Allocates whole function declaration IR code and injects code into it
    */
-  allocStackFrameInstructions(content: () => string[]): string[] {
+  allocStackFrameInstructions(contentFn: X86StackFrameContentFn): string[] {
     const { config } = this;
     const { arch } = config;
 
     this._stackFrame = new X86StackFrame(config);
 
     switch (arch) {
-      case CCompilerArch.X86_16:
+      case CCompilerArch.X86_16: {
+        const content = contentFn();
+
         return [
           genInstruction('push', 'bp'),
           genInstruction('mov', 'bp', 'sp'),
-          ...content(),
+          ...content.asm,
           genInstruction('pop', 'bp'),
+          ...content.ret,
         ];
+      }
 
       default:
         assertUnreachable(arch);

--- a/packages/compiler-pico-c/src/arch/x86/backend/X86Allocator.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/X86Allocator.ts
@@ -4,7 +4,7 @@ import { IRBlockIterator } from '@compiler/pico-c/frontend/ir/iterator/IRBlockIt
 
 import { X86StackFrame } from './X86StackFrame';
 import { X86BasicRegAllocator } from './reg-allocator';
-import { genInstruction, genLabel } from '../asm-utils';
+import { genInstruction, genLabelName } from '../asm-utils';
 
 export class X86Allocator {
   private readonly labels: { [id: string]: string } = {};
@@ -38,8 +38,8 @@ export class X86Allocator {
   /**
    * Allocates plain jmp label
    */
-  allocLabelInstruction(type: 'fn', id: string): string {
-    const label = genLabel(`${type}_${id}`);
+  allocLabel(type: 'fn', id: string): string {
+    const label = genLabelName(`${type}_${id}`);
 
     this.labels[id] = label;
     return label;

--- a/packages/compiler-pico-c/src/arch/x86/backend/X86ArchBackend.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/X86ArchBackend.ts
@@ -1,37 +1,27 @@
-import { IRScopeGeneratorResult } from '@compiler/pico-c/frontend/ir/generator';
 import { IRBlockIterator } from '@compiler/pico-c/frontend/ir/iterator/IRBlockIterator';
-
 import { CCompilerArch } from '@compiler/pico-c/constants';
 import { CAbstractArchBackend } from '@compiler/pico-c/backend/abstract/CAbstractArchBackend';
 import { CBackendCompilerResult } from '@compiler/pico-c/backend/constants/types';
 
+import {
+  IRScopeGeneratorResult,
+  IRFlatCodeSegmentBuilderResult,
+} from '@compiler/pico-c/frontend/ir/generator';
+
+import { BackendCompiledFunctions } from '../constants/types';
 import { X86Allocator } from './X86Allocator';
 import { compileDataSegment, compileInstructionsBlock } from './compilers';
-import { getCompilerArchDescriptor } from '../..';
+import { getCompilerArchDescriptor } from '../../../arch';
 
 export class X86ArchBackend extends CAbstractArchBackend {
   static readonly arch = CCompilerArch.X86_16;
+  static readonly cpu = '386';
 
   compileIR({ segments }: IRScopeGeneratorResult): CBackendCompilerResult {
-    const asm: string[] = ['cpu 386'];
-
-    for (const [, fn] of Object.entries(segments.code.functions)) {
-      const iterator = IRBlockIterator.of(fn.block.instructions);
-      const allocator = new X86Allocator(this.config, iterator);
-
-      asm.push(
-        ...compileInstructionsBlock({
-          context: {
-            arch: X86ArchBackend.arch,
-            archDescriptor: getCompilerArchDescriptor(X86ArchBackend.arch),
-            iterator,
-            allocator,
-          },
-        }),
-      );
-    }
+    const asm: string[] = [`cpu ${X86ArchBackend.cpu}`];
 
     asm.push(
+      ...this.compileIRFunctions(segments.code),
       ...compileDataSegment({
         segment: segments.data,
       }),
@@ -40,5 +30,37 @@ export class X86ArchBackend extends CAbstractArchBackend {
     return {
       asm: asm.join('\n'),
     };
+  }
+
+  private compileIRFunctions(
+    codeSegment: IRFlatCodeSegmentBuilderResult,
+  ): string[] {
+    const compiledFunctions: BackendCompiledFunctions = {};
+
+    for (const [, fn] of Object.entries(codeSegment.functions)) {
+      const iterator = IRBlockIterator.of(fn.block.instructions);
+      const allocator = new X86Allocator(this.config, iterator);
+
+      compiledFunctions[fn.declaration.name] = {
+        ...fn,
+        asm: compileInstructionsBlock({
+          context: {
+            arch: X86ArchBackend.arch,
+            archDescriptor: getCompilerArchDescriptor(X86ArchBackend.arch),
+            codeSegment,
+            iterator,
+            allocator,
+            compiled: {
+              functions: compiledFunctions,
+            },
+          },
+        }),
+      };
+    }
+
+    return Object.values(compiledFunctions).reduce((acc, { asm }) => {
+      acc.push(...asm);
+      return acc;
+    }, [] as string[]);
   }
 }

--- a/packages/compiler-pico-c/src/arch/x86/backend/X86ArchBackend.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/X86ArchBackend.ts
@@ -9,9 +9,9 @@ import {
 } from '@compiler/pico-c/frontend/ir/generator';
 
 import { X86Allocator } from './X86Allocator';
-import { BackendCompilerContext } from '../constants/types';
+import { X86BackendCompilerContext } from '../constants/types';
 import {
-  BackendCompiledFunctions,
+  X86BackendCompiledFunctions,
   X86FunctionResolver,
 } from './X86FunctionResolver';
 
@@ -40,7 +40,7 @@ export class X86ArchBackend extends CAbstractArchBackend {
   private compileIRFunctions(
     codeSegment: IRFlatCodeSegmentBuilderResult,
   ): string[] {
-    const compiledFunctions: BackendCompiledFunctions = {};
+    const compiledFunctions: X86BackendCompiledFunctions = {};
 
     for (const [, fn] of Object.entries(codeSegment.functions)) {
       const { name } = fn.declaration;
@@ -49,7 +49,7 @@ export class X86ArchBackend extends CAbstractArchBackend {
       const allocator = new X86Allocator(this.config, iterator);
       const fnResolver = new X86FunctionResolver(compiledFunctions);
 
-      const context: BackendCompilerContext = {
+      const context: X86BackendCompilerContext = {
         arch: X86ArchBackend.arch,
         archDescriptor: getCompilerArchDescriptor(X86ArchBackend.arch),
         codeSegment,

--- a/packages/compiler-pico-c/src/arch/x86/backend/X86FunctionResolver.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/X86FunctionResolver.ts
@@ -1,0 +1,19 @@
+import type { IRCodeFunctionBlock } from '@compiler/pico-c/frontend/ir/generator';
+
+export type BackendCompiledFunctions = Record<
+  string,
+  IRCodeFunctionBlock & {
+    asm: {
+      code: string[];
+      label: string;
+    };
+  }
+>;
+
+export class X86FunctionResolver {
+  constructor(private readonly compiled: BackendCompiledFunctions) {}
+
+  tryResolveFnLabel(name: string) {
+    return this.compiled[name].asm.label;
+  }
+}

--- a/packages/compiler-pico-c/src/arch/x86/backend/X86FunctionResolver.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/X86FunctionResolver.ts
@@ -1,19 +1,25 @@
 import type { IRCodeFunctionBlock } from '@compiler/pico-c/frontend/ir/generator';
 
-export type BackendCompiledFunctions = Record<
+export type X86BackendCompiledFunction = IRCodeFunctionBlock & {
+  asm: {
+    code: string[];
+    label: string;
+  };
+};
+
+export type X86BackendCompiledFunctions = Record<
   string,
-  IRCodeFunctionBlock & {
-    asm: {
-      code: string[];
-      label: string;
-    };
-  }
+  X86BackendCompiledFunction
 >;
 
 export class X86FunctionResolver {
-  constructor(private readonly compiled: BackendCompiledFunctions) {}
+  constructor(private readonly compiled: X86BackendCompiledFunctions) {}
 
-  tryResolveFnLabel(name: string) {
-    return this.compiled[name].asm.label;
+  tryResolveFnBlock(name: string): X86BackendCompiledFunction {
+    return this.compiled[name];
+  }
+
+  tryResolveFnLabel(name: string): string {
+    return this.tryResolveFnBlock(name).asm.label;
   }
 }

--- a/packages/compiler-pico-c/src/arch/x86/backend/X86StackFrame.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/X86StackFrame.ts
@@ -44,6 +44,11 @@ export class X86StackFrame {
     return -this.allocated;
   }
 
+  allocRawStackVariable(stackVar: X86StackVariable): X86StackVariable {
+    this.stackVars[stackVar.name] = stackVar;
+    return stackVar;
+  }
+
   allocLocalVariable(variable: IRVariable): X86StackVariable {
     const size = X86StackFrame.getStackAllocVariableSize(variable);
     const offset = this.allocBytes(size);
@@ -61,7 +66,7 @@ export class X86StackFrame {
     const { arch } = this.config;
     const stackOffset = this.getStackVarOffset(name);
 
-    if (stackOffset + offset >= 0) {
+    if (offset < 0 && stackOffset + offset >= 0) {
       throw new CBackendError(CBackendErrorCode.OFFSET_OVERFLOW, { name });
     }
 

--- a/packages/compiler-pico-c/src/arch/x86/backend/X86StackFrame.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/X86StackFrame.ts
@@ -3,7 +3,7 @@ import { isPointerLikeType } from '@compiler/pico-c/frontend/analyze';
 import { assertUnreachable } from '@compiler/core/utils';
 
 import {
-  IRInstructionVarArg,
+  IRInstructionTypedArg,
   IRVariable,
   isIRVariable,
 } from '@compiler/pico-c/frontend/ir/variables';
@@ -77,7 +77,7 @@ export class X86StackFrame {
     }
   }
 
-  static getStackAllocVariableSize(variable: IRInstructionVarArg) {
+  static getStackAllocVariableSize(variable: IRInstructionTypedArg) {
     const { type } = variable;
 
     // IR variables are always pointers

--- a/packages/compiler-pico-c/src/arch/x86/backend/call-conventions/X86CdeclFnCaller.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/call-conventions/X86CdeclFnCaller.ts
@@ -1,0 +1,39 @@
+import { genInstruction } from '../../asm-utils';
+import {
+  X86ConventionalFnCaller,
+  X86FnCallerCompilerAttrs,
+} from './X86ConventionalFnCaller';
+
+export class X86CdeclFnCaller implements X86ConventionalFnCaller {
+  compileIRFnCall({
+    context,
+    target,
+    callerInstruction,
+  }: X86FnCallerCompilerAttrs): string[] {
+    const { allocator } = context;
+    const regs = allocator.regs.ownership.getAvailableRegs();
+
+    const stackSize = regs.general.size;
+    const stackReg = regs.stack;
+
+    const totalArgs = callerInstruction.args.length;
+    const asm: string[] = [];
+
+    // alloc args
+    for (let i = totalArgs - 1; i >= 0; --i) {
+      const resolvedArg = allocator.regs.tryResolveIrArg({
+        arg: callerInstruction.args[i],
+        size: stackSize,
+      });
+
+      asm.push(...resolvedArg.asm, genInstruction('push', resolvedArg.value));
+    }
+
+    // call
+    asm.push(genInstruction('call', target.asm.label));
+
+    // cleanup
+    asm.push(genInstruction('add', stackReg, totalArgs * stackSize));
+    return asm;
+  }
+}

--- a/packages/compiler-pico-c/src/arch/x86/backend/call-conventions/X86CdeclFnCaller.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/call-conventions/X86CdeclFnCaller.ts
@@ -1,26 +1,33 @@
-import { genInstruction } from '../../asm-utils';
+import { X86RegName } from '@x86-toolkit/assembler/index';
+import { genComment, genInstruction } from '../../asm-utils';
 import { getX86RegByteSize } from '../../constants/regs';
-import { X86BackendCompilerContext } from '../../constants/types';
+import { X86Allocator } from '../X86Allocator';
 import { X86StackFrame } from '../X86StackFrame';
 import {
   X86ConventionalFnCaller,
+  X86FnBasicCompilerAttrs,
   X86FnCallerCompilerAttrs,
-  X86FnDefStackArgsCompilerAttrs,
+  X86FnRetCompilerAttrs,
 } from './X86ConventionalFnCaller';
 
 export class X86CdeclFnCaller implements X86ConventionalFnCaller {
+  /**
+   * Compiles `call` opcode and pushes args
+   */
   compileIRFnCall({
     context,
     target,
     callerInstruction,
   }: X86FnCallerCompilerAttrs): string[] {
     const { allocator } = context;
+    const { declaration } = target;
+    const { regs } = allocator;
 
-    const stack = this.getContextStackInfo(context);
+    const stack = this.getContextStackInfo(allocator);
     const totalArgs = callerInstruction.args.length;
     const asm: string[] = [];
 
-    // alloc args
+    // call function section
     for (let i = totalArgs - 1; i >= 0; --i) {
       const resolvedArg = allocator.regs.tryResolveIrArg({
         arg: callerInstruction.args[i],
@@ -30,22 +37,31 @@ export class X86CdeclFnCaller implements X86ConventionalFnCaller {
       asm.push(...resolvedArg.asm, genInstruction('push', resolvedArg.value));
     }
 
-    // call and cleanup
-    asm.push(
-      genInstruction('call', target.asm.label),
-      genInstruction('add', stack.reg, totalArgs * stack.size),
-    );
+    asm.push(genInstruction('call', target.asm.label));
+
+    // restore result from register (AX is already loaded in `compileIRFnRet`)
+    if (
+      callerInstruction.outputVar &&
+      !declaration.isVoid() &&
+      declaration.hasReturnValueInReg()
+    ) {
+      regs.ownership.setOwnership(callerInstruction.outputVar.name, {
+        reg: this.getReturnReg(allocator),
+      });
+    }
 
     return asm;
   }
 
-  allocIRFnDefStackArgs({
-    context,
-    declaration,
-  }: X86FnDefStackArgsCompilerAttrs) {
-    const { stackFrame, regs } = context.allocator;
+  /**
+   * Reads all args in `def` instruction
+   */
+  allocIRFnDefStackArgs({ context, declaration }: X86FnBasicCompilerAttrs) {
+    const { allocator } = context;
+    const { stackFrame, regs } = allocator;
     const { args } = declaration;
-    const stack = this.getContextStackInfo(context);
+
+    const stack = this.getContextStackInfo(allocator);
 
     for (let i = args.length - 1; i >= 0; --i) {
       const arg = args[i];
@@ -61,7 +77,50 @@ export class X86CdeclFnCaller implements X86ConventionalFnCaller {
     }
   }
 
-  private getContextStackInfo({ allocator }: X86BackendCompilerContext) {
+  /**
+   * Returns `ret` instruction opcode and assigns ownership on reg
+   */
+  compileIRFnRet({
+    context,
+    declaration,
+    retInstruction,
+  }: X86FnRetCompilerAttrs): string[] {
+    const { allocator } = context;
+
+    const stack = this.getContextStackInfo(allocator);
+    const totalArgs = declaration.args.length;
+    const asm: string[] = [];
+
+    if (!declaration.isVoid() && declaration.hasReturnValueInReg()) {
+      if (retInstruction.value) {
+        // handle case when we call `return 2`
+        const retResolvedArg = allocator.regs.tryResolveIRArgAsReg({
+          size: declaration.returnRegType.getByteSize(),
+          arg: retInstruction.value,
+          allowedRegs: [this.getReturnReg(allocator)],
+        });
+
+        asm.push(...retResolvedArg.asm);
+      } else {
+        // handle case when we skip `return` stmt but instruction has return type
+        asm.push(genComment('missing return'));
+      }
+    }
+
+    if (totalArgs) {
+      asm.push(genInstruction('ret', totalArgs * stack.size));
+    } else {
+      asm.push(genInstruction('ret'));
+    }
+
+    return asm;
+  }
+
+  private getReturnReg(allocator: X86Allocator): X86RegName {
+    return allocator.regs.ownership.getAvailableRegs().general.list[0];
+  }
+
+  private getContextStackInfo(allocator: X86Allocator) {
     const reg = allocator.regs.ownership.getAvailableRegs().stack;
     const size = getX86RegByteSize(reg);
 

--- a/packages/compiler-pico-c/src/arch/x86/backend/call-conventions/X86CdeclFnCaller.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/call-conventions/X86CdeclFnCaller.ts
@@ -74,7 +74,7 @@ export class X86CdeclFnCaller implements X86ConventionalFnCaller {
       const arg = args[i];
       const stackVar = stackFrame.allocRawStackVariable({
         name: arg.name,
-        offset: (args.length - i) * stack.size,
+        offset: (i + 1) * stack.size,
         size: X86StackFrame.getStackAllocVariableSize(arg),
       });
 

--- a/packages/compiler-pico-c/src/arch/x86/backend/call-conventions/X86CdeclFnCaller.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/call-conventions/X86CdeclFnCaller.ts
@@ -50,6 +50,13 @@ export class X86CdeclFnCaller implements X86ConventionalFnCaller {
       });
     }
 
+    // handle case when we call `sum(void)` with `sum(1, 2, 3)`.
+    // Cleanup `1`, .. args stack because `ret` function does not do that
+    const argsCountDelta = totalArgs - declaration.args.length;
+    if (argsCountDelta) {
+      asm.push(genInstruction('add', stack.reg, argsCountDelta * stack.size));
+    }
+
     return asm;
   }
 

--- a/packages/compiler-pico-c/src/arch/x86/backend/call-conventions/X86CdeclFnCaller.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/call-conventions/X86CdeclFnCaller.ts
@@ -1,7 +1,11 @@
 import { genInstruction } from '../../asm-utils';
+import { getX86RegByteSize } from '../../constants/regs';
+import { X86BackendCompilerContext } from '../../constants/types';
+import { X86StackFrame } from '../X86StackFrame';
 import {
   X86ConventionalFnCaller,
   X86FnCallerCompilerAttrs,
+  X86FnDefStackArgsCompilerAttrs,
 } from './X86ConventionalFnCaller';
 
 export class X86CdeclFnCaller implements X86ConventionalFnCaller {
@@ -11,11 +15,8 @@ export class X86CdeclFnCaller implements X86ConventionalFnCaller {
     callerInstruction,
   }: X86FnCallerCompilerAttrs): string[] {
     const { allocator } = context;
-    const regs = allocator.regs.ownership.getAvailableRegs();
 
-    const stackSize = regs.general.size;
-    const stackReg = regs.stack;
-
+    const stack = this.getContextStackInfo(context);
     const totalArgs = callerInstruction.args.length;
     const asm: string[] = [];
 
@@ -23,17 +24,50 @@ export class X86CdeclFnCaller implements X86ConventionalFnCaller {
     for (let i = totalArgs - 1; i >= 0; --i) {
       const resolvedArg = allocator.regs.tryResolveIrArg({
         arg: callerInstruction.args[i],
-        size: stackSize,
+        size: stack.size,
       });
 
       asm.push(...resolvedArg.asm, genInstruction('push', resolvedArg.value));
     }
 
-    // call
-    asm.push(genInstruction('call', target.asm.label));
+    // call and cleanup
+    asm.push(
+      genInstruction('call', target.asm.label),
+      genInstruction('add', stack.reg, totalArgs * stack.size),
+    );
 
-    // cleanup
-    asm.push(genInstruction('add', stackReg, totalArgs * stackSize));
     return asm;
+  }
+
+  allocIRFnDefStackArgs({
+    context,
+    declaration,
+  }: X86FnDefStackArgsCompilerAttrs) {
+    const { stackFrame, regs } = context.allocator;
+    const { args } = declaration;
+    const stack = this.getContextStackInfo(context);
+
+    for (let i = args.length - 1; i >= 0; --i) {
+      const arg = args[i];
+      const stackVar = stackFrame.allocRawStackVariable({
+        name: arg.name,
+        offset: (args.length - i) * stack.size,
+        size: X86StackFrame.getStackAllocVariableSize(arg),
+      });
+
+      regs.ownership.setOwnership(arg.name, {
+        stackVar,
+      });
+    }
+  }
+
+  private getContextStackInfo({ allocator }: X86BackendCompilerContext) {
+    const reg = allocator.regs.ownership.getAvailableRegs().stack;
+    const size = getX86RegByteSize(reg);
+
+    return {
+      reg,
+      size,
+    };
   }
 }

--- a/packages/compiler-pico-c/src/arch/x86/backend/call-conventions/X86ConventionalFnCaller.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/call-conventions/X86ConventionalFnCaller.ts
@@ -1,4 +1,8 @@
-import { IRCallInstruction } from '@compiler/pico-c/frontend/ir/instructions';
+import {
+  IRCallInstruction,
+  IRFnDeclInstruction,
+} from '@compiler/pico-c/frontend/ir/instructions';
+
 import { X86BackendCompilerContext } from '../../constants/types';
 import { X86BackendCompiledFunction } from '../X86FunctionResolver';
 
@@ -8,6 +12,12 @@ export type X86FnCallerCompilerAttrs = {
   callerInstruction: IRCallInstruction;
 };
 
+export type X86FnDefStackArgsCompilerAttrs = {
+  declaration: IRFnDeclInstruction;
+  context: X86BackendCompilerContext;
+};
+
 export interface X86ConventionalFnCaller {
   compileIRFnCall(attrs: X86FnCallerCompilerAttrs): string[];
+  allocIRFnDefStackArgs(attrs: X86FnDefStackArgsCompilerAttrs): void;
 }

--- a/packages/compiler-pico-c/src/arch/x86/backend/call-conventions/X86ConventionalFnCaller.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/call-conventions/X86ConventionalFnCaller.ts
@@ -1,0 +1,13 @@
+import { IRCallInstruction } from '@compiler/pico-c/frontend/ir/instructions';
+import { X86BackendCompilerContext } from '../../constants/types';
+import { X86BackendCompiledFunction } from '../X86FunctionResolver';
+
+export type X86FnCallerCompilerAttrs = {
+  context: X86BackendCompilerContext;
+  target: X86BackendCompiledFunction;
+  callerInstruction: IRCallInstruction;
+};
+
+export interface X86ConventionalFnCaller {
+  compileIRFnCall(attrs: X86FnCallerCompilerAttrs): string[];
+}

--- a/packages/compiler-pico-c/src/arch/x86/backend/call-conventions/X86ConventionalFnCaller.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/call-conventions/X86ConventionalFnCaller.ts
@@ -1,6 +1,7 @@
 import {
   IRCallInstruction,
   IRFnDeclInstruction,
+  IRRetInstruction,
 } from '@compiler/pico-c/frontend/ir/instructions';
 
 import { X86BackendCompilerContext } from '../../constants/types';
@@ -12,12 +13,17 @@ export type X86FnCallerCompilerAttrs = {
   callerInstruction: IRCallInstruction;
 };
 
-export type X86FnDefStackArgsCompilerAttrs = {
+export type X86FnBasicCompilerAttrs = {
   declaration: IRFnDeclInstruction;
   context: X86BackendCompilerContext;
 };
 
+export type X86FnRetCompilerAttrs = X86FnBasicCompilerAttrs & {
+  retInstruction: IRRetInstruction;
+};
+
 export interface X86ConventionalFnCaller {
   compileIRFnCall(attrs: X86FnCallerCompilerAttrs): string[];
-  allocIRFnDefStackArgs(attrs: X86FnDefStackArgsCompilerAttrs): void;
+  compileIRFnRet(attrs: X86FnRetCompilerAttrs): string[];
+  allocIRFnDefStackArgs(attrs: X86FnBasicCompilerAttrs): void;
 }

--- a/packages/compiler-pico-c/src/arch/x86/backend/call-conventions/X86StdcallFnCaller.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/call-conventions/X86StdcallFnCaller.ts
@@ -10,7 +10,7 @@ import {
   X86FnRetCompilerAttrs,
 } from './X86ConventionalFnCaller';
 
-export class X86CdeclFnCaller implements X86ConventionalFnCaller {
+export class X86StdcallFnCaller implements X86ConventionalFnCaller {
   /**
    * Compiles `call` opcode and pushes args
    */

--- a/packages/compiler-pico-c/src/arch/x86/backend/call-conventions/index.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/call-conventions/index.ts
@@ -1,13 +1,13 @@
 import { CFunctionCallConvention } from '@compiler/pico-c/constants';
 
 import type { X86ConventionalFnCaller } from './X86ConventionalFnCaller';
-import { X86CdeclFnCaller } from './X86CdeclFnCaller';
+import { X86StdcallFnCaller } from './X86StdcallFnCaller';
 
 const X86ConventionalFnCallers: Record<
   CFunctionCallConvention,
   X86ConventionalFnCaller
 > = {
-  [CFunctionCallConvention.CDECL]: new X86CdeclFnCaller(),
+  [CFunctionCallConvention.STDCALL]: new X86StdcallFnCaller(),
 };
 
 export const getX86FnCaller = (

--- a/packages/compiler-pico-c/src/arch/x86/backend/call-conventions/index.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/call-conventions/index.ts
@@ -1,0 +1,15 @@
+import { CFunctionCallConvention } from '@compiler/pico-c/constants';
+
+import type { X86ConventionalFnCaller } from './X86ConventionalFnCaller';
+import { X86CdeclFnCaller } from './X86CdeclFnCaller';
+
+const X86ConventionalFnCallers: Record<
+  CFunctionCallConvention,
+  X86ConventionalFnCaller
+> = {
+  [CFunctionCallConvention.CDECL]: new X86CdeclFnCaller(),
+};
+
+export const getX86FnCaller = (
+  convention: CFunctionCallConvention,
+): X86ConventionalFnCaller => X86ConventionalFnCallers[convention];

--- a/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileAllocInstruction.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileAllocInstruction.ts
@@ -1,8 +1,8 @@
 import { IRAllocInstruction } from '@compiler/pico-c/frontend/ir/instructions';
-import { CompilerInstructionFnAttrs } from '../../constants/types';
+import { X86CompilerInstructionFnAttrs } from '../../constants/types';
 
 type AllocInstructionCompilerAttrs =
-  CompilerInstructionFnAttrs<IRAllocInstruction>;
+  X86CompilerInstructionFnAttrs<IRAllocInstruction>;
 
 export function compileAllocInstruction({
   instruction,

--- a/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileAssignInstruction.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileAssignInstruction.ts
@@ -1,10 +1,10 @@
 import { IRAssignInstruction } from '@compiler/pico-c/frontend/ir/instructions';
-import { CompilerInstructionFnAttrs } from '../../constants/types';
+import { X86CompilerInstructionFnAttrs } from '../../constants/types';
 import { genInstruction, withInlineComment } from '../../asm-utils';
 import { isIRConstant } from '@compiler/pico-c/frontend/ir/variables';
 
 type AssignInstructionCompilerAttrs =
-  CompilerInstructionFnAttrs<IRAssignInstruction>;
+  X86CompilerInstructionFnAttrs<IRAssignInstruction>;
 
 export function compileAssignInstruction({
   instruction,

--- a/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileAssignInstruction.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileAssignInstruction.ts
@@ -17,6 +17,9 @@ export function compileAssignInstruction({
   const outputReg = regs.tryResolveIRArgAsReg({
     arg: meta.phi?.vars[0] || outputVar,
     allocIfNotFound: true,
+    ...(meta?.preferAddressRegsOutput && {
+      preferRegs: allocator.regs.ownership.getAvailableRegs().addressing,
+    }),
   });
 
   regs.ownership.setOwnership(outputVar.name, {

--- a/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileCallInstruction.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileCallInstruction.ts
@@ -1,0 +1,20 @@
+import { IRCallInstruction } from '@compiler/pico-c/frontend/ir/instructions';
+import { CompilerInstructionFnAttrs } from '../../constants/types';
+
+import { isIRLabel } from '@compiler/pico-c/frontend/ir/variables';
+import { genInstruction } from '../../asm-utils';
+
+type CallInstructionCompilerAttrs =
+  CompilerInstructionFnAttrs<IRCallInstruction>;
+
+export function compileCallInstruction({
+  instruction,
+  context,
+}: CallInstructionCompilerAttrs) {
+  const { fnResolver } = context;
+  const callTarget = isIRLabel(instruction.fnPtr)
+    ? fnResolver.tryResolveFnLabel(instruction.fnPtr.name)
+    : 'todo';
+
+  return [genInstruction('call', callTarget)];
+}

--- a/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileFnDeclInstructionsBlock.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileFnDeclInstructionsBlock.ts
@@ -7,7 +7,7 @@ import {
 
 import { CompiledBlockOutput, CompilerFnAttrs } from '../../constants/types';
 
-import { genComment } from '../../asm-utils';
+import { genComment, genLabel } from '../../asm-utils';
 
 import { compileAllocInstruction } from './compileAllocInstruction';
 import { compileStoreInstruction } from './compileStoreInstruction';
@@ -21,6 +21,7 @@ import { compileAssignInstruction } from './compileAssignInstruction';
 import { compilePhiInstruction } from './compilePhiInstruction';
 import { compileRetInstruction } from './compileRetInstruction';
 import { compileLabelOffsetInstruction } from './compileLabelOffsetInstruction';
+import { compileCallInstruction } from './compileCallInstruction';
 
 type FnDeclCompilerBlockFnAttrs = CompilerFnAttrs & {
   instruction: IRFnDeclInstruction;
@@ -78,6 +79,10 @@ export function compileFnDeclInstructionsBlock({
           asm.push(...compileJmpInstruction(arg));
           break;
 
+        case IROpcode.CALL:
+          asm.push(...compileCallInstruction(arg));
+          break;
+
         case IROpcode.LABEL:
           asm.push(...compileLabelInstruction(arg));
           break;
@@ -101,7 +106,7 @@ export function compileFnDeclInstructionsBlock({
 
   const asm = [
     genComment(fnInstruction.getDisplayName()),
-    allocator.allocLabelInstruction('fn', fnInstruction.name),
+    genLabel(allocator.allocLabel('fn', fnInstruction.name), false),
     ...allocator.allocStackFrameInstructions(compileFnContent),
     ...compileRetInstruction(),
   ];

--- a/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileFnDeclInstructionsBlock.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileFnDeclInstructionsBlock.ts
@@ -20,6 +20,7 @@ import { compileLeaInstruction } from './compileLeaInstruction';
 import { compileAssignInstruction } from './compileAssignInstruction';
 import { compilePhiInstruction } from './compilePhiInstruction';
 import { compileRetInstruction } from './compileRetInstruction';
+import { compileLabelOffsetInstruction } from './compileLabelOffsetInstruction';
 
 type FnDeclCompilerBlockFnAttrs = CompilerFnAttrs & {
   instruction: IRFnDeclInstruction;
@@ -79,6 +80,10 @@ export function compileFnDeclInstructionsBlock({
 
         case IROpcode.LABEL:
           asm.push(...compileLabelInstruction(arg));
+          break;
+
+        case IROpcode.LABEL_OFFSET:
+          compileLabelOffsetInstruction(arg);
           break;
 
         case IROpcode.ICMP:

--- a/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileFnDeclInstructionsBlock.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileFnDeclInstructionsBlock.ts
@@ -5,7 +5,10 @@ import {
   isIRLabelInstruction,
 } from '@compiler/pico-c/frontend/ir/instructions';
 
-import { CompiledBlockOutput, CompilerFnAttrs } from '../../constants/types';
+import {
+  X86CompiledBlockOutput,
+  X86CompilerFnAttrs,
+} from '../../constants/types';
 
 import { genComment, genLabel } from '../../asm-utils';
 
@@ -23,14 +26,14 @@ import { compileRetInstruction } from './compileRetInstruction';
 import { compileLabelOffsetInstruction } from './compileLabelOffsetInstruction';
 import { compileCallInstruction } from './compileCallInstruction';
 
-type FnDeclCompilerBlockFnAttrs = CompilerFnAttrs & {
+type FnDeclCompilerBlockFnAttrs = X86CompilerFnAttrs & {
   instruction: IRFnDeclInstruction;
 };
 
 export function compileFnDeclInstructionsBlock({
   instruction: fnInstruction,
   context,
-}: FnDeclCompilerBlockFnAttrs): CompiledBlockOutput {
+}: FnDeclCompilerBlockFnAttrs): X86CompiledBlockOutput {
   const { allocator, iterator } = context;
   const compileFnContent = (): string[] => {
     const asm: string[] = [];

--- a/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileFnDeclInstructionsBlock.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileFnDeclInstructionsBlock.ts
@@ -11,6 +11,7 @@ import {
 } from '../../constants/types';
 
 import { genComment, genLabel } from '../../asm-utils';
+import { getX86FnCaller } from '../call-conventions';
 
 import { compileAllocInstruction } from './compileAllocInstruction';
 import { compileStoreInstruction } from './compileStoreInstruction';
@@ -37,6 +38,11 @@ export function compileFnDeclInstructionsBlock({
   const { allocator, iterator } = context;
   const compileFnContent = (): string[] => {
     const asm: string[] = [];
+
+    getX86FnCaller(fnInstruction.type.callConvention).allocIRFnDefStackArgs({
+      declaration: fnInstruction,
+      context,
+    });
 
     iterator.walk(instruction => {
       const arg = {

--- a/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileICmpInstruction.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileICmpInstruction.ts
@@ -17,7 +17,7 @@ import {
 } from '../../asm-utils';
 
 import { IRArgDynamicResolverType } from '../reg-allocator';
-import { CompilerInstructionFnAttrs } from '../../constants/types';
+import { X86CompilerInstructionFnAttrs } from '../../constants/types';
 import { getBiggerIRArg } from '@compiler/pico-c/frontend/ir/utils';
 
 const OPERATOR_JMP_INSTRUCTIONS: Record<CRelOperator, [string, string]> = {
@@ -30,7 +30,7 @@ const OPERATOR_JMP_INSTRUCTIONS: Record<CRelOperator, [string, string]> = {
 };
 
 type ICmpInstructionCompilerAttrs =
-  CompilerInstructionFnAttrs<IRICmpInstruction>;
+  X86CompilerInstructionFnAttrs<IRICmpInstruction>;
 
 export function compileICmpInstruction({
   instruction,

--- a/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileInstructionsBlock.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileInstructionsBlock.ts
@@ -4,12 +4,12 @@ import {
   IRFnDeclInstruction,
 } from '@compiler/pico-c/frontend/ir/instructions';
 
-import { CompilerFnAttrs } from '../../constants/types';
+import { X86CompilerFnAttrs } from '../../constants/types';
 
 import { genComment } from '../../asm-utils';
 import { compileFnDeclInstructionsBlock } from './compileFnDeclInstructionsBlock';
 
-type InstructionBlockCompilerAttrs = CompilerFnAttrs;
+type InstructionBlockCompilerAttrs = X86CompilerFnAttrs;
 
 export function compileInstructionsBlock({
   context,

--- a/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileJmpInstruction.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileJmpInstruction.ts
@@ -1,13 +1,14 @@
 import { IRJmpInstruction } from '@compiler/pico-c/frontend/ir/instructions';
 
-import { CompilerInstructionFnAttrs } from '../../constants/types';
+import { X86CompilerInstructionFnAttrs } from '../../constants/types';
 import {
   genInstruction,
   genLabelName,
   withInlineComment,
 } from '../../asm-utils';
 
-type JmpInstructionCompilerAttrs = CompilerInstructionFnAttrs<IRJmpInstruction>;
+type JmpInstructionCompilerAttrs =
+  X86CompilerInstructionFnAttrs<IRJmpInstruction>;
 
 export function compileJmpInstruction({
   instruction,

--- a/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileLabelInstruction.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileLabelInstruction.ts
@@ -1,9 +1,9 @@
 import { IRLabelInstruction } from '@compiler/pico-c/frontend/ir/instructions';
-import { CompilerInstructionFnAttrs } from '../../constants/types';
+import { X86CompilerInstructionFnAttrs } from '../../constants/types';
 import { genLabel } from '../../asm-utils';
 
 type LabelInstructionCompilerAttrs =
-  CompilerInstructionFnAttrs<IRLabelInstruction>;
+  X86CompilerInstructionFnAttrs<IRLabelInstruction>;
 
 export function compileLabelInstruction({
   instruction,

--- a/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileLabelOffsetInstruction.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileLabelOffsetInstruction.ts
@@ -1,0 +1,21 @@
+import { IRLabelOffsetInstruction } from '@compiler/pico-c/frontend/ir/instructions';
+import { CompilerInstructionFnAttrs } from '../../constants/types';
+
+type LabelOffsetInstructionCompilerAttrs =
+  CompilerInstructionFnAttrs<IRLabelOffsetInstruction>;
+
+export function compileLabelOffsetInstruction({
+  instruction,
+  context,
+}: LabelOffsetInstructionCompilerAttrs) {
+  const { outputVar } = instruction;
+  const { allocator, compiled } = context;
+
+  setTimeout(() => {
+    console.info({
+      compiled,
+      outputVar,
+      allocator,
+    });
+  }, 0);
+}

--- a/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileLabelOffsetInstruction.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileLabelOffsetInstruction.ts
@@ -8,14 +8,10 @@ export function compileLabelOffsetInstruction({
   instruction,
   context,
 }: LabelOffsetInstructionCompilerAttrs) {
-  const { outputVar } = instruction;
-  const { allocator, compiled } = context;
+  const { label } = instruction;
+  const { fnResolver } = context;
 
   setTimeout(() => {
-    console.info({
-      compiled,
-      outputVar,
-      allocator,
-    });
+    console.info('TODO:', fnResolver.tryResolveFnLabel(label.name));
   }, 0);
 }

--- a/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileLabelOffsetInstruction.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileLabelOffsetInstruction.ts
@@ -1,8 +1,8 @@
 import { IRLabelOffsetInstruction } from '@compiler/pico-c/frontend/ir/instructions';
-import { CompilerInstructionFnAttrs } from '../../constants/types';
+import { X86CompilerInstructionFnAttrs } from '../../constants/types';
 
 type LabelOffsetInstructionCompilerAttrs =
-  CompilerInstructionFnAttrs<IRLabelOffsetInstruction>;
+  X86CompilerInstructionFnAttrs<IRLabelOffsetInstruction>;
 
 export function compileLabelOffsetInstruction({
   instruction,

--- a/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileLeaInstruction.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileLeaInstruction.ts
@@ -6,14 +6,15 @@ import {
 import { CPrimitiveType } from '@compiler/pico-c/frontend/analyze';
 import { IRLeaInstruction } from '@compiler/pico-c/frontend/ir/instructions';
 
-import { CompilerInstructionFnAttrs } from '../../constants/types';
+import { X86CompilerInstructionFnAttrs } from '../../constants/types';
 import {
   genInstruction,
   genLabelName,
   withInlineComment,
 } from '../../asm-utils';
 
-type LeaInstructionCompilerAttrs = CompilerInstructionFnAttrs<IRLeaInstruction>;
+type LeaInstructionCompilerAttrs =
+  X86CompilerInstructionFnAttrs<IRLeaInstruction>;
 
 export function compileLeaInstruction({
   instruction,

--- a/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileLeaInstruction.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileLeaInstruction.ts
@@ -47,15 +47,12 @@ export function compileLeaInstruction({
   }
 
   // int* a = &k;
-  if (!inputVar.isTemporary()) {
+  const stackAddress = stackFrame.getLocalVarStackRelAddress(inputVar.name);
+  if (stackAddress) {
     return [
       ...addressReg.asm,
       withInlineComment(
-        genInstruction(
-          'lea',
-          addressReg.value,
-          stackFrame.getLocalVarStackRelAddress(inputVar.name),
-        ),
+        genInstruction('lea', addressReg.value, stackAddress),
         instruction.getDisplayName(),
       ),
     ];

--- a/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileLoadInstruction.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileLoadInstruction.ts
@@ -42,8 +42,11 @@ export function compileLoadInstruction({
       });
     }
 
-    const regSize = inputVar.type.baseType.getByteSize();
     const outputRegSize = outputVar.type.getByteSize();
+    const regSize = Math.min(
+      outputRegSize,
+      inputVar.type.baseType.getByteSize(),
+    );
 
     const reg = regs.requestReg({
       size: regSize,

--- a/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileLoadInstruction.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileLoadInstruction.ts
@@ -8,11 +8,11 @@ import { isIRVariable } from '@compiler/pico-c/frontend/ir/variables';
 import { isPointerLikeType } from '@compiler/pico-c/frontend/analyze';
 import { isStackVarOwnership } from '../reg-allocator/utils';
 
-import { CompilerInstructionFnAttrs } from '../../constants/types';
+import { X86CompilerInstructionFnAttrs } from '../../constants/types';
 import { genInstruction, withInlineComment } from '../../asm-utils';
 
 type LoadInstructionCompilerAttrs =
-  CompilerInstructionFnAttrs<IRLoadInstruction>;
+  X86CompilerInstructionFnAttrs<IRLoadInstruction>;
 
 export function compileLoadInstruction({
   instruction,

--- a/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileLoadInstruction.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileLoadInstruction.ts
@@ -24,7 +24,7 @@ export function compileLoadInstruction({
   } = context;
 
   if (!isIRVariable(inputVar)) {
-    return;
+    throw new CBackendError(CBackendErrorCode.UNKNOWN_BACKEND_ERROR);
   }
 
   const asm: string[] = [];

--- a/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileMathInstruction.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileMathInstruction.ts
@@ -103,7 +103,10 @@ export function compileMathInstruction({
 
         asm.push(
           ...reg.asm,
-          genInstruction('mov', reg.value, leftAllocResult.value),
+          withInlineComment(
+            genInstruction('mov', reg.value, leftAllocResult.value),
+            `swap - ${instruction.getDisplayName()}`,
+          ),
         );
 
         regs.ownership.setOwnership(leftVar.name, {

--- a/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileMathInstruction.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileMathInstruction.ts
@@ -10,11 +10,11 @@ import { isIRVariable } from '@compiler/pico-c/frontend/ir/variables';
 import { getBiggerIRArg } from '@compiler/pico-c/frontend/ir/utils';
 
 import { IRArgDynamicResolverType } from '../reg-allocator';
-import { CompilerInstructionFnAttrs } from '../../constants/types';
+import { X86CompilerInstructionFnAttrs } from '../../constants/types';
 import { genInstruction, withInlineComment } from '../../asm-utils';
 
 type MathInstructionCompilerAttrs =
-  CompilerInstructionFnAttrs<IRMathInstruction>;
+  X86CompilerInstructionFnAttrs<IRMathInstruction>;
 
 export function compileMathInstruction({
   instruction,

--- a/packages/compiler-pico-c/src/arch/x86/backend/compilers/compilePhiInstruction.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/compilers/compilePhiInstruction.ts
@@ -4,10 +4,11 @@ import {
 } from '@compiler/pico-c/backend/errors/CBackendError';
 import { IRPhiInstruction } from '@compiler/pico-c/frontend/ir/instructions';
 
-import { CompilerInstructionFnAttrs } from '../../constants/types';
+import { X86CompilerInstructionFnAttrs } from '../../constants/types';
 import { IRRegOwnership, isRegOwnership } from '../reg-allocator/utils';
 
-type PhiInstructionCompilerAttrs = CompilerInstructionFnAttrs<IRPhiInstruction>;
+type PhiInstructionCompilerAttrs =
+  X86CompilerInstructionFnAttrs<IRPhiInstruction>;
 
 export function compilePhiInstruction({
   instruction,

--- a/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileRetInstruction.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileRetInstruction.ts
@@ -1,5 +1,24 @@
-import { genInstruction } from '../../asm-utils';
+import {
+  IRFnDeclInstruction,
+  IRRetInstruction,
+} from '@compiler/pico-c/frontend/ir/instructions';
 
-export function compileRetInstruction() {
-  return [genInstruction('ret')];
+import { X86CompilerInstructionFnAttrs } from '../../constants/types';
+import { getX86FnCaller } from '../call-conventions';
+
+type RetInstructionCompilerAttrs =
+  X86CompilerInstructionFnAttrs<IRRetInstruction> & {
+    fnInstruction: IRFnDeclInstruction;
+  };
+
+export function compileRetInstruction({
+  context,
+  instruction,
+  fnInstruction,
+}: RetInstructionCompilerAttrs) {
+  return getX86FnCaller(fnInstruction.type.callConvention).compileIRFnRet({
+    declaration: fnInstruction,
+    retInstruction: instruction,
+    context,
+  });
 }

--- a/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileStoreInstruction.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/compilers/compileStoreInstruction.ts
@@ -13,7 +13,7 @@ import {
   isIRVariable,
 } from '@compiler/pico-c/frontend/ir/variables';
 
-import { CompilerInstructionFnAttrs } from '../../constants/types';
+import { X86CompilerInstructionFnAttrs } from '../../constants/types';
 import {
   genInstruction,
   genMemAddress,
@@ -26,7 +26,7 @@ import {
 } from '@compiler/pico-c/frontend/analyze';
 
 type StoreInstructionCompilerAttrs =
-  CompilerInstructionFnAttrs<IRStoreInstruction>;
+  X86CompilerInstructionFnAttrs<IRStoreInstruction>;
 
 export function compileStoreInstruction({
   instruction,

--- a/packages/compiler-pico-c/src/arch/x86/backend/compilers/index.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/compilers/index.ts
@@ -6,6 +6,7 @@ export * from './compileICmpInstruction';
 export * from './compileInstructionsBlock';
 export * from './compileJmpInstruction';
 export * from './compileLabelInstruction';
+export * from './compileLabelOffsetInstruction';
 export * from './compileLeaInstruction';
 export * from './compileLoadInstruction';
 export * from './compileMathInstruction';

--- a/packages/compiler-pico-c/src/arch/x86/backend/compilers/index.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/compilers/index.ts
@@ -1,5 +1,6 @@
 export * from './compileAllocInstruction';
 export * from './compileAssignInstruction';
+export * from './compileCallInstruction';
 export * from './compileDataSegment';
 export * from './compileFnDeclInstructionsBlock';
 export * from './compileICmpInstruction';

--- a/packages/compiler-pico-c/src/arch/x86/backend/reg-allocator/X86BasicRegAllocator.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/reg-allocator/X86BasicRegAllocator.ts
@@ -7,7 +7,7 @@ import {
 } from '@compiler/pico-c/backend/errors/CBackendError';
 
 import {
-  IRInstructionVarArg,
+  IRInstructionTypedArg,
   IRVariable,
   isIRConstant,
   isIRVariable,
@@ -56,13 +56,13 @@ export type IRDynamicArgAllocatorResult =
   | IRArgAllocatorTypedResult<IRArgDynamicResolverType.NUMBER, number>;
 
 export type IRArgDynamicResolverAttrs = {
-  arg: IRInstructionVarArg;
+  arg: IRInstructionTypedArg;
   size?: number;
   allow?: IRArgDynamicResolverType;
 };
 
 export type IRArgRegResolverAttrs = {
-  arg: IRInstructionVarArg;
+  arg: IRInstructionTypedArg;
   size?: number;
   allocIfNotFound?: boolean;
   allowedRegs?: X86RegName[];

--- a/packages/compiler-pico-c/src/arch/x86/backend/reg-allocator/X86RegOwnershipTracker.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/reg-allocator/X86RegOwnershipTracker.ts
@@ -51,6 +51,7 @@ export class X86RegOwnershipTracker {
 
     if (isRegOwnership(item)) {
       const ownerships = this.getOwnershipByReg(item.reg);
+
       if (ownerships.length === 1) {
         this.releaseRegs([item.reg]);
       }

--- a/packages/compiler-pico-c/src/arch/x86/backend/utils/getStoreOutputByteSize.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/utils/getStoreOutputByteSize.ts
@@ -1,0 +1,26 @@
+import {
+  getBaseTypeIfPtr,
+  getSourceNonPtrType,
+} from '@compiler/pico-c/frontend/analyze/types/utils';
+
+import {
+  CType,
+  isArrayLikeType,
+  isStructLikeType,
+} from '@compiler/pico-c/frontend/analyze';
+
+export const getStoreOutputByteSize = (type: CType, offset: number) => {
+  const baseOutputType = getBaseTypeIfPtr(type);
+
+  if (isStructLikeType(baseOutputType)) {
+    return baseOutputType.getFlattenFieldTypeByOffset(offset).getByteSize();
+  }
+
+  if (isArrayLikeType(baseOutputType)) {
+    const arrayItem = getSourceNonPtrType(baseOutputType);
+
+    return getStoreOutputByteSize(arrayItem, offset % arrayItem.getByteSize());
+  }
+
+  return baseOutputType.getByteSize();
+};

--- a/packages/compiler-pico-c/src/arch/x86/backend/utils/index.ts
+++ b/packages/compiler-pico-c/src/arch/x86/backend/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './getStoreOutputByteSize';
 export * from './queryFromX86IntRegsMap';
 export * from './recursiveSetAvailabilityInX86RegMap';
 export * from './recursiveX86RegMapLookup';

--- a/packages/compiler-pico-c/src/arch/x86/constants/regs.ts
+++ b/packages/compiler-pico-c/src/arch/x86/constants/regs.ts
@@ -20,6 +20,7 @@ export type X86IntRegTree = {
 };
 
 export type RegsMap = {
+  stack: X86RegName;
   addressing: Array<X86RegName>;
   general: {
     size: number;
@@ -34,6 +35,7 @@ export type RegsMap = {
 
 export const createX86RegsMap = (): Record<CCompilerArch, RegsMap> => ({
   [CCompilerArch.X86_16]: {
+    stack: 'sp',
     addressing: ['bx', 'si', 'di'],
     general: {
       size: 2,

--- a/packages/compiler-pico-c/src/arch/x86/constants/types.ts
+++ b/packages/compiler-pico-c/src/arch/x86/constants/types.ts
@@ -7,7 +7,7 @@ import type { CArchDescriptor } from '../../types';
 import type { X86Allocator } from '../backend/X86Allocator';
 import type { X86FunctionResolver } from '../backend/X86FunctionResolver';
 
-export type BackendCompilerContext = {
+export type X86BackendCompilerContext = {
   arch: CCompilerArch;
   archDescriptor: Readonly<CArchDescriptor>;
   allocator: X86Allocator;
@@ -16,15 +16,15 @@ export type BackendCompilerContext = {
   fnResolver: X86FunctionResolver;
 };
 
-export type CompilerFnAttrs = {
-  context: BackendCompilerContext;
+export type X86CompilerFnAttrs = {
+  context: X86BackendCompilerContext;
 };
 
-export type CompilerInstructionFnAttrs<I extends IRInstruction> =
-  CompilerFnAttrs & {
+export type X86CompilerInstructionFnAttrs<I extends IRInstruction> =
+  X86CompilerFnAttrs & {
     instruction: I;
   };
 
-export type CompiledBlockOutput = {
+export type X86CompiledBlockOutput = {
   asm: string[];
 };

--- a/packages/compiler-pico-c/src/arch/x86/constants/types.ts
+++ b/packages/compiler-pico-c/src/arch/x86/constants/types.ts
@@ -1,20 +1,11 @@
 import type { CCompilerArch } from '@compiler/pico-c/constants';
-import type {
-  IRCodeFunctionBlock,
-  IRFlatCodeSegmentBuilderResult,
-} from '@compiler/pico-c/frontend/ir/generator';
+import type { IRFlatCodeSegmentBuilderResult } from '@compiler/pico-c/frontend/ir/generator';
 
 import type { IRInstruction } from '@compiler/pico-c/frontend/ir/instructions';
 import type { IRBlockIterator } from '@compiler/pico-c/frontend/ir/iterator/IRBlockIterator';
 import type { CArchDescriptor } from '../../types';
 import type { X86Allocator } from '../backend/X86Allocator';
-
-export type BackendCompiledFunctions = Record<
-  string,
-  IRCodeFunctionBlock & {
-    asm: string[];
-  }
->;
+import type { X86FunctionResolver } from '../backend/X86FunctionResolver';
 
 export type BackendCompilerContext = {
   arch: CCompilerArch;
@@ -22,9 +13,7 @@ export type BackendCompilerContext = {
   allocator: X86Allocator;
   iterator: IRBlockIterator;
   codeSegment: IRFlatCodeSegmentBuilderResult;
-  compiled: {
-    functions: BackendCompiledFunctions;
-  };
+  fnResolver: X86FunctionResolver;
 };
 
 export type CompilerFnAttrs = {

--- a/packages/compiler-pico-c/src/arch/x86/constants/types.ts
+++ b/packages/compiler-pico-c/src/arch/x86/constants/types.ts
@@ -1,14 +1,30 @@
 import type { CCompilerArch } from '@compiler/pico-c/constants';
+import type {
+  IRCodeFunctionBlock,
+  IRFlatCodeSegmentBuilderResult,
+} from '@compiler/pico-c/frontend/ir/generator';
+
 import type { IRInstruction } from '@compiler/pico-c/frontend/ir/instructions';
 import type { IRBlockIterator } from '@compiler/pico-c/frontend/ir/iterator/IRBlockIterator';
 import type { CArchDescriptor } from '../../types';
 import type { X86Allocator } from '../backend/X86Allocator';
+
+export type BackendCompiledFunctions = Record<
+  string,
+  IRCodeFunctionBlock & {
+    asm: string[];
+  }
+>;
 
 export type BackendCompilerContext = {
   arch: CCompilerArch;
   archDescriptor: Readonly<CArchDescriptor>;
   allocator: X86Allocator;
   iterator: IRBlockIterator;
+  codeSegment: IRFlatCodeSegmentBuilderResult;
+  compiled: {
+    functions: BackendCompiledFunctions;
+  };
 };
 
 export type CompilerFnAttrs = {

--- a/packages/compiler-pico-c/src/backend/safeGenAsmIRCode.ts
+++ b/packages/compiler-pico-c/src/backend/safeGenAsmIRCode.ts
@@ -7,6 +7,8 @@ import { CAbstractArchBackend } from './abstract/CAbstractArchBackend';
 import { CBackendCompilerResult } from './constants/types';
 import { CBackendError, CBackendErrorCode } from './errors/CBackendError';
 
+// import { IRResultView } from '../frontend/ir';
+
 type CAbstractBackendConstructor = {
   new (config: CCompilerConfig): CAbstractArchBackend;
 };
@@ -24,6 +26,8 @@ export function genASMIRCode(
 ): Result<CBackendCompilerResult, CBackendError[]> {
   try {
     const CompilerBackend = CCOMPILER_ARCH_BACKENDS[config.arch];
+
+    // console.info(IRResultView.serializeToString(ir));
 
     return ok(new CompilerBackend(config).compileIR(ir));
   } catch (e) {

--- a/packages/compiler-pico-c/src/constants/lang.ts
+++ b/packages/compiler-pico-c/src/constants/lang.ts
@@ -9,7 +9,7 @@ export enum CStructAlign {
 }
 
 export enum CFunctionCallConvention {
-  CDECL = 'CDECL',
+  STDCALL = 'STDCALL',
 }
 
 export enum CStorageClassSpecifier {

--- a/packages/compiler-pico-c/src/frontend/analyze/ast/initializer-builder/builder/CTypeInitializerBuilderVisitor.ts
+++ b/packages/compiler-pico-c/src/frontend/analyze/ast/initializer-builder/builder/CTypeInitializerBuilderVisitor.ts
@@ -252,7 +252,7 @@ export class CTypeInitializerBuilderVisitor extends CInnerTypeTreeVisitor {
           );
         }
 
-        offset += field.getIndex();
+        offset += field.index;
         baseType = field.type;
       }
 

--- a/packages/compiler-pico-c/src/frontend/analyze/ast/type-builder/builder/CTreeTypeBuilderVisitor.ts
+++ b/packages/compiler-pico-c/src/frontend/analyze/ast/type-builder/builder/CTreeTypeBuilderVisitor.ts
@@ -162,7 +162,7 @@ export class CTreeTypeBuilderVisitor extends CInnerTypeTreeVisitor {
     );
 
     this.type = new CFunctionDeclType({
-      callConvention: CFunctionCallConvention.CDECL,
+      callConvention: CFunctionCallConvention.STDCALL,
       name: null,
       definition: null,
       returnType: this.type,

--- a/packages/compiler-pico-c/src/frontend/analyze/ast/type-builder/creators/ASTCFunctionDefTypeCreator.ts
+++ b/packages/compiler-pico-c/src/frontend/analyze/ast/type-builder/creators/ASTCFunctionDefTypeCreator.ts
@@ -75,7 +75,7 @@ export class ASTCFunctionDefTypeCreator extends ASTCTypeCreator<ASTCFunctionDefi
 
     return new CFunctionDeclType({
       definition: fnDefinition.content,
-      callConvention: CFunctionCallConvention.CDECL,
+      callConvention: CFunctionCallConvention.STDCALL,
       name: returnTypeEntry.name,
       returnType: returnTypeEntry.type,
       arch,

--- a/packages/compiler-pico-c/src/frontend/analyze/scope/variables/CVariableInitializerTree.ts
+++ b/packages/compiler-pico-c/src/frontend/analyze/scope/variables/CVariableInitializerTree.ts
@@ -77,6 +77,8 @@ export class CVariableInitializerTree<
       fields[i] = text.charCodeAt(i);
     }
 
+    fields[text.length] = 0x0;
+
     return new CVariableInitializerTree(baseType, parentAST, fields);
   }
 

--- a/packages/compiler-pico-c/src/frontend/analyze/types/struct/constants/types.ts
+++ b/packages/compiler-pico-c/src/frontend/analyze/types/struct/constants/types.ts
@@ -12,10 +12,10 @@ export type CStructEntryDescriptor = CNamedTypedEntryDescriptor & {
 };
 
 export class CStructEntry extends CNamedTypedEntry<CStructEntryDescriptor> {
-  getOffset() {
+  get offset() {
     return this.value.offset;
   }
-  getIndex() {
+  get index() {
     return this.value.index;
   }
 }

--- a/packages/compiler-pico-c/src/frontend/analyze/types/utils/getBaseTypeIfPtr.ts
+++ b/packages/compiler-pico-c/src/frontend/analyze/types/utils/getBaseTypeIfPtr.ts
@@ -1,0 +1,10 @@
+import { isPointerLikeType } from '../CPointerType';
+import type { CType } from '../CType';
+
+export function getBaseTypeIfPtr(type: CType): CType {
+  if (isPointerLikeType(type)) {
+    return type.baseType;
+  }
+
+  return type;
+}

--- a/packages/compiler-pico-c/src/frontend/analyze/types/utils/index.ts
+++ b/packages/compiler-pico-c/src/frontend/analyze/types/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './getBaseTypeIfPtr';
 export * from './getSourceNonPtrType';
 export * from './isImplicitPtrType';
 export * from './typeofValueOrNode';

--- a/packages/compiler-pico-c/src/frontend/ir/generator/IRVariableAllocator.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/generator/IRVariableAllocator.ts
@@ -196,9 +196,16 @@ export class IRVariableAllocator {
    */
   allocFunctionType(fn: CFunctionDeclType): IRFnDeclInstruction {
     const { name, returnType, args } = fn;
-    const irDefArgs = args.map(arg =>
-      this.allocAsPointer(IRVariable.ofScopeVariable(arg)),
-    );
+    const irDefArgs = args.map(arg => {
+      let scopeVar = IRVariable.ofScopeVariable(arg);
+
+      // handle case when we pass struct to function
+      if (!arg.type.canBeStoredInReg()) {
+        scopeVar = scopeVar.ofPointerType();
+      }
+
+      return this.allocAsPointer(scopeVar);
+    });
 
     const irFn = (() => {
       if (returnType.isVoid()) {

--- a/packages/compiler-pico-c/src/frontend/ir/generator/IRVariableAllocator.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/generator/IRVariableAllocator.ts
@@ -196,16 +196,9 @@ export class IRVariableAllocator {
    */
   allocFunctionType(fn: CFunctionDeclType): IRFnDeclInstruction {
     const { name, returnType, args } = fn;
-    const irDefArgs = args.map(arg => {
-      let scopeVar = IRVariable.ofScopeVariable(arg);
-
-      // handle case when we pass struct to function
-      if (!arg.type.canBeStoredInReg()) {
-        scopeVar = scopeVar.ofPointerType();
-      }
-
-      return this.allocAsPointer(scopeVar);
-    });
+    const irDefArgs = args.map(arg =>
+      this.allocAsPointer(IRVariable.ofScopeVariable(arg)),
+    );
 
     const irFn = (() => {
       if (returnType.isVoid()) {
@@ -222,7 +215,7 @@ export class IRVariableAllocator {
         irDefArgs,
         null,
         this.allocTmpVariable(
-          CPointerType.ofType(CPointerType.ofType(returnType)),
+          CPointerType.ofType(returnType),
           TMP_FN_RETURN_VAR_PREFIX,
         ),
       );

--- a/packages/compiler-pico-c/src/frontend/ir/generator/emitters/emit-expr/emitExpressionIR.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/generator/emitters/emit-expr/emitExpressionIR.ts
@@ -21,6 +21,7 @@ import {
   CVariableInitializerTree,
   isPointerArithmeticType,
   isPointerLikeType,
+  isStructLikeType,
 } from '@compiler/pico-c/frontend/analyze';
 
 import {
@@ -65,6 +66,7 @@ import { emitIdentifierGetterIR } from '../emitIdentifierGetterIR';
 import { emitIncExpressionIR } from '../emitIncExpressionIR';
 import { emitFnCallExpressionIR } from '../emit-fn-call-expression';
 import { emitLogicBinaryJmpExpressionIR } from './emitLogicBinaryJmpExpressionIR';
+import { emitStructShallowCopyIR } from './emitStructShallowCopyIR';
 
 export type ExpressionIREmitAttrs = IREmitterContextAttrs & {
   node: ASTCCompilerNode;
@@ -296,8 +298,22 @@ export function emitExpressionIR({
               const tmpVar = allocNextVariable(srcVar.type);
 
               instructions.push(new IRLeaInstruction(srcVar, tmpVar));
+            } else if (
+              isStructLikeType(srcVar.type.baseType) &&
+              !srcVar.type.baseType.canBeStoredInReg() &&
+              1 > 4
+            ) {
+              // handle "struct" array, perform shallow copy by value
+              // of provided type
+              emitExprResultToStack(
+                emitStructShallowCopyIR({
+                  allocator,
+                  type: srcVar.type.baseType,
+                }),
+              );
             } else {
-              // handle normal "ptr" variable, loads its pointing value
+              // handle normal "a" variable, loads its pointing value
+              // basically `a = 2`
               const tmpVar = allocNextVariable(srcVar.type.baseType);
               instructions.push(new IRLoadInstruction(srcVar, tmpVar));
             }

--- a/packages/compiler-pico-c/src/frontend/ir/generator/emitters/emit-expr/emitExpressionIR.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/generator/emitters/emit-expr/emitExpressionIR.ts
@@ -299,7 +299,6 @@ export function emitExpressionIR({
             } else {
               // handle normal "ptr" variable, loads its pointing value
               const tmpVar = allocNextVariable(srcVar.type.baseType);
-
               instructions.push(new IRLoadInstruction(srcVar, tmpVar));
             }
           } else {

--- a/packages/compiler-pico-c/src/frontend/ir/generator/emitters/emit-expr/emitExpressionIR.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/generator/emitters/emit-expr/emitExpressionIR.ts
@@ -56,7 +56,8 @@ import {
 import { IRError, IRErrorCode } from '../../../errors/IRError';
 import {
   IRConstant,
-  IRInstructionVarArg,
+  IRInstructionTypedArg,
+  IRLabel,
   IRVariable,
 } from '../../../variables';
 
@@ -80,7 +81,7 @@ export function emitExpressionIR({
 
   const result = createBlankExprResult();
   const { instructions } = result;
-  let argsVarsStack: IRInstructionVarArg[] = [];
+  let argsVarsStack: IRInstructionTypedArg[] = [];
 
   const pushNextVariable = (variable: IRVariable) => {
     argsVarsStack.push(variable);
@@ -279,7 +280,9 @@ export function emitExpressionIR({
           if (srcFn) {
             const tmpVar = allocNextVariable(CPointerType.ofType(srcFn.type));
 
-            instructions.push(new IRLabelOffsetInstruction(srcFn, tmpVar));
+            instructions.push(
+              new IRLabelOffsetInstruction(IRLabel.ofName(srcFn.name), tmpVar),
+            );
           } else if (srcVar) {
             // handle a[2] / *a
             if (!isPointerLikeType(srcVar.type)) {

--- a/packages/compiler-pico-c/src/frontend/ir/generator/emitters/emit-expr/emitStructShallowCopyIR.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/generator/emitters/emit-expr/emitStructShallowCopyIR.ts
@@ -1,0 +1,33 @@
+import { CStructType } from '@compiler/pico-c/frontend/analyze';
+import { IRAllocInstruction, IRLeaInstruction } from '../../../instructions';
+import { IRVariableAllocator } from '../../IRVariableAllocator';
+import {
+  createBlankExprResult,
+  type IREmitterExpressionResult,
+} from '../types';
+
+type ShallowCopyIRAttrs = {
+  type: CStructType;
+  allocator: IRVariableAllocator;
+};
+
+export function emitStructShallowCopyIR({
+  type,
+  allocator,
+}: ShallowCopyIRAttrs): IREmitterExpressionResult {
+  const result = createBlankExprResult();
+  const structAllocVar = allocator.allocTmpPointer(type);
+  const structPtrVar = allocator.allocTmpPointer(structAllocVar.type);
+
+  result.output = structPtrVar;
+  result.instructions.push(
+    new IRAllocInstruction(type, structAllocVar),
+    new IRLeaInstruction(structAllocVar, structPtrVar),
+  );
+
+  setTimeout(() => {
+    console.info('xDD', type.getDisplayName());
+  });
+
+  return result;
+}

--- a/packages/compiler-pico-c/src/frontend/ir/generator/emitters/emit-fn-call-expression/emitFnArgsLoadIR.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/generator/emitters/emit-fn-call-expression/emitFnArgsLoadIR.ts
@@ -6,7 +6,7 @@ import {
   ASTCCompilerNode,
 } from '@compiler/pico-c/frontend/parser';
 
-import { IRInstructionVarArg } from '../../../variables';
+import { IRInstructionTypedArg } from '../../../variables';
 import {
   appendStmtResults,
   createBlankStmtResult,
@@ -24,7 +24,7 @@ export function emitFnArgsLoadIR({
 }: FnArgsLoadIREmitAttrs) {
   const { emit } = context;
   const result = createBlankStmtResult();
-  const args: IRInstructionVarArg[] = [];
+  const args: IRInstructionTypedArg[] = [];
 
   GroupTreeVisitor.ofIterator<ASTCCompilerNode>({
     [ASTCCompilerKind.AssignmentExpression]: {

--- a/packages/compiler-pico-c/src/frontend/ir/generator/emitters/emit-fn-call-expression/emitFnCallExpressionIR.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/generator/emitters/emit-fn-call-expression/emitFnCallExpressionIR.ts
@@ -115,8 +115,8 @@ export function emitFnCallExpressionIR({
       );
     }
   } else {
-    output = allocator.allocTmpVariable(fnType.returnType);
-    const outputPtr = allocator.allocTmpPointer(output.type);
+    output = allocator.allocTmpPointer(fnType.returnType);
+    const outputPtr = allocator.allocTmpPointer(fnType.returnType);
 
     result.instructions.push(
       new IRAllocInstruction(fnType.returnType, output),

--- a/packages/compiler-pico-c/src/frontend/ir/generator/emitters/emit-fn-decl/emitBlockItemIR.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/generator/emitters/emit-fn-decl/emitBlockItemIR.ts
@@ -163,7 +163,8 @@ export function emitBlockItemIR({
           result = functionRvoStmtTransformer({
             stmtResult: result,
             returnedVar: assignResult.output,
-            rvoOutputVar: context.parent.fnDecl.outputVarPtr,
+            rvoOutputVar: context.parent.fnDecl.outputVar,
+            context: context,
           });
 
           result.instructions.push(new IRRetInstruction());

--- a/packages/compiler-pico-c/src/frontend/ir/generator/emitters/emit-fn-decl/emitBlockItemIR.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/generator/emitters/emit-fn-decl/emitBlockItemIR.ts
@@ -139,9 +139,12 @@ export function emitBlockItemIR({
 
     [ASTCCompilerKind.ReturnStmt]: {
       enter(expr: ASTCExpression) {
-        const canBeStoredInReg =
-          context.parent.fnDecl.type.returnType.canBeStoredInIntegralReg();
+        const fnReturnType = context.parent.fnDecl.type.returnType;
+        if (fnReturnType.isVoid()) {
+          return false;
+        }
 
+        const canBeStoredInReg = fnReturnType.canBeStoredInIntegralReg();
         let assignResult = emitExpressionIR({
           node: expr,
           scope,

--- a/packages/compiler-pico-c/src/frontend/ir/generator/emitters/emit-fn-decl/functionRvoStmtTransformer.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/generator/emitters/emit-fn-decl/functionRvoStmtTransformer.ts
@@ -44,6 +44,7 @@ export function functionRvoStmtTransformer({
         rvoOutputVar,
         instruction.outputVar,
       );
+
       optimized = true;
       break;
     } else {

--- a/packages/compiler-pico-c/src/frontend/ir/generator/emitters/emitIdentifierGetterIR.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/generator/emitters/emitIdentifierGetterIR.ts
@@ -36,7 +36,8 @@ import {
 
 import {
   IRConstant,
-  IRInstructionVarArg,
+  IRInstructionTypedArg,
+  IRLabel,
   IRVariable,
   isIRVariable,
 } from '../../variables';
@@ -163,7 +164,10 @@ export function emitIdentifierGetterIR({
             );
 
             instructions.push(
-              new IRLabelOffsetInstruction(irFunction, lastIRVar),
+              new IRLabelOffsetInstruction(
+                IRLabel.ofName(irFunction.name),
+                lastIRVar,
+              ),
             );
           } else {
             const irVariable = allocator.getVariable(name);
@@ -313,7 +317,7 @@ export function emitIdentifierGetterIR({
           });
 
         instructions.push(...exprInstructions);
-        let offsetAddressVar: IRInstructionVarArg = null;
+        let offsetAddressVar: IRInstructionTypedArg = null;
 
         if (isIRVariable(exprOutput)) {
           if (isPointerLikeType(exprOutput.type)) {

--- a/packages/compiler-pico-c/src/frontend/ir/generator/emitters/emitIdentifierGetterIR.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/generator/emitters/emitIdentifierGetterIR.ts
@@ -222,7 +222,7 @@ export function emitIdentifierGetterIR({
 
         const offsetConstant = IRConstant.ofConstant(
           CPrimitiveType.int(config.arch),
-          parentType.baseType.getField(expr.name.text).getOffset(),
+          parentType.baseType.getField(expr.name.text).offset,
         );
 
         if (offsetConstant.constant) {
@@ -253,7 +253,8 @@ export function emitIdentifierGetterIR({
 
         if (
           isPointerLikeType(lastIRVar.type) &&
-          isStructLikeType(lastIRVar.type.baseType)
+          isStructLikeType(lastIRVar.type.baseType) &&
+          !lastIRVar.isTemporary()
         ) {
           instructions.push(
             new IRLeaInstruction(
@@ -265,7 +266,7 @@ export function emitIdentifierGetterIR({
 
         const offsetConstant = IRConstant.ofConstant(
           CPrimitiveType.int(config.arch),
-          parentType.getField(expr.name.text).getOffset(),
+          parentType.getField(expr.name.text).offset,
         );
 
         if (offsetConstant.constant) {
@@ -362,10 +363,17 @@ export function emitIdentifierGetterIR({
   })(node);
 
   if (emitValueAtAddress && lastIRVar && isPointerLikeType(lastIRVar.type)) {
-    const outputVar = allocator.allocTmpVariable(lastIRVar.type.baseType);
-    instructions.push(
-      new IRLoadInstruction(lastIRVar, outputVar.ofType(node.type!)),
+    // handle loading data into identifier IR
+    // example: int k = vec.x;
+    // last variable is `x` from `vec` but `IR` returned `Vec2*`
+    // it has to be auto-casted to `int`
+    const outputVar = allocator.allocTmpVariable(
+      lastIRVar.type.baseType.isPrimitive()
+        ? lastIRVar.type.baseType
+        : node.type,
     );
+
+    instructions.push(new IRLoadInstruction(lastIRVar, outputVar));
 
     return {
       output: outputVar,

--- a/packages/compiler-pico-c/src/frontend/ir/instructions/IRAssignInstruction.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/instructions/IRAssignInstruction.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import { IsOutputInstruction } from '../interfaces';
 import { IROpcode } from '../constants';
 import { IRInstruction, IRInstructionArgs } from './IRInstruction';
-import { IRInstructionVarArg, IRVariable } from '../variables';
+import { IRInstructionTypedArg, IRVariable } from '../variables';
 import { IRPhiInstruction } from './IRPhiInstruction';
 
 export type IRAssignMeta = {
@@ -26,7 +26,7 @@ export class IRAssignInstruction
   implements IsOutputInstruction
 {
   constructor(
-    readonly inputVar: IRInstructionVarArg,
+    readonly inputVar: IRInstructionTypedArg,
     readonly outputVar: IRVariable,
     readonly meta: IRAssignMeta = {
       virtual: false,
@@ -39,7 +39,7 @@ export class IRAssignInstruction
     input = [this.inputVar],
     output = this.outputVar,
   }: IRInstructionArgs) {
-    return new IRAssignInstruction(input[0], output);
+    return new IRAssignInstruction(<IRInstructionTypedArg>input[0], output);
   }
 
   override getArgs(): IRInstructionArgs {

--- a/packages/compiler-pico-c/src/frontend/ir/instructions/IRAssignInstruction.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/instructions/IRAssignInstruction.ts
@@ -8,6 +8,7 @@ import { IRPhiInstruction } from './IRPhiInstruction';
 
 export type IRAssignMeta = {
   virtual?: boolean;
+  preferAddressRegsOutput?: boolean;
   phi?: IRPhiInstruction;
 };
 

--- a/packages/compiler-pico-c/src/frontend/ir/instructions/IRBrInstruction.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/instructions/IRBrInstruction.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 
 import { IROpcode } from '../constants';
 import { HasLabeledBranches } from '../interfaces';
-import { IRInstructionVarArg } from '../variables';
+import { IRInstructionTypedArg } from '../variables';
 import { IRInstruction } from './IRInstruction';
 import { IRLabelInstruction } from './IRLabelInstruction';
 
@@ -25,7 +25,7 @@ export class IRBrInstruction
   implements IRBranchRelations<IRLabelInstruction>, HasLabeledBranches
 {
   constructor(
-    readonly variable: IRInstructionVarArg,
+    readonly variable: IRInstructionTypedArg,
     readonly ifTrue: IRLabelInstruction,
     readonly ifFalse?: IRLabelInstruction,
   ) {

--- a/packages/compiler-pico-c/src/frontend/ir/instructions/IRCallInstruction.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/instructions/IRCallInstruction.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import { IsOutputInstruction } from '../interfaces';
 import { IROpcode } from '../constants';
 import { IRInstruction, IRInstructionArgs } from './IRInstruction';
-import { IRVariable, IRInstructionVarArg } from '../variables';
+import { IRVariable, IRInstructionTypedArg, IRLabel } from '../variables';
 
 export function isIRCallInstruction(
   instruction: IRInstruction,
@@ -19,18 +19,26 @@ export class IRCallInstruction
   implements IsOutputInstruction
 {
   constructor(
-    readonly fnPtr: IRVariable,
-    readonly args: IRInstructionVarArg[],
+    readonly fnPtr: IRVariable | IRLabel,
+    readonly args: IRInstructionTypedArg[],
     readonly outputVar?: IRVariable,
   ) {
     super(IROpcode.CALL);
+  }
+
+  ofFnPtr(fnPtr: IRVariable | IRLabel) {
+    return new IRCallInstruction(fnPtr, this.args, this.outputVar);
   }
 
   override ofArgs({
     input: [fnPtr, ...restInput],
     output = this.outputVar,
   }: IRInstructionArgs) {
-    return new IRCallInstruction(<IRVariable>fnPtr, restInput, output);
+    return new IRCallInstruction(
+      <IRVariable>fnPtr,
+      <IRInstructionTypedArg[]>restInput,
+      output,
+    );
   }
 
   override getArgs(): IRInstructionArgs {

--- a/packages/compiler-pico-c/src/frontend/ir/instructions/IRFnDeclInstruction.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/instructions/IRFnDeclInstruction.ts
@@ -25,33 +25,39 @@ export class IRFnDeclInstruction
     readonly type: CFunctionDeclType,
     readonly name: string,
     readonly args: IRVariable[],
-    readonly returnRegType?: CType,
-    readonly outputVarPtr: IRVariable = null,
+    readonly returnType?: CType,
+    readonly outputVar: IRVariable = null,
     readonly variadic: boolean = false,
   ) {
     super(IROpcode.FN_DECL);
   }
 
-  hasReturnValueInReg() {
-    return !!this.returnRegType;
+  getArgsWithRVO() {
+    const { args, outputVar } = this;
+
+    return outputVar ? [...args, outputVar] : args;
+  }
+
+  hasReturnValue() {
+    return !!this.returnType;
   }
 
   isVoid() {
-    const { returnRegType, outputVarPtr } = this;
+    const { returnType, outputVar } = this;
 
-    return !returnRegType && !outputVarPtr;
+    return !returnType && !outputVar;
   }
 
   override getDisplayName(): string {
-    const { name, args, returnRegType, outputVarPtr } = this;
+    const { name, args, returnType, outputVar } = this;
 
     const serializedArgs = args.map(arg => arg.getDisplayName());
-    const retStr = returnRegType
-      ? `: [ret${getIRTypeDisplayName(returnRegType)}]`
+    const retStr = returnType
+      ? `: [ret${getIRTypeDisplayName(returnType)}]`
       : ':';
 
-    if (outputVarPtr) {
-      serializedArgs.push(outputVarPtr.getDisplayName());
+    if (outputVar) {
+      serializedArgs.push(outputVar.getDisplayName());
     }
 
     return `${chalk.bold.yellow('def')} ${chalk.bold.white(

--- a/packages/compiler-pico-c/src/frontend/ir/instructions/IRFnDeclInstruction.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/instructions/IRFnDeclInstruction.ts
@@ -32,6 +32,10 @@ export class IRFnDeclInstruction
     super(IROpcode.FN_DECL);
   }
 
+  hasReturnValueInReg() {
+    return !!this.returnRegType;
+  }
+
   isVoid() {
     const { returnRegType, outputVarPtr } = this;
 

--- a/packages/compiler-pico-c/src/frontend/ir/instructions/IRICmpInstruction.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/instructions/IRICmpInstruction.ts
@@ -3,7 +3,7 @@ import { CRelOperator } from '@compiler/pico-c/constants';
 import { IROpcode } from '../constants';
 import { IROpInstruction } from './IROpInstruction';
 import { IRInstruction } from './IRInstruction';
-import { IRInstructionVarArg, IRVariable } from '../variables';
+import { IRInstructionTypedArg, IRVariable } from '../variables';
 
 export function isIRICmpInstruction(
   instruction: IRInstruction,
@@ -17,8 +17,8 @@ export function isIRICmpInstruction(
 export class IRICmpInstruction extends IROpInstruction<CRelOperator> {
   constructor(
     operator: CRelOperator,
-    leftVar: IRInstructionVarArg,
-    rightVar: IRInstructionVarArg,
+    leftVar: IRInstructionTypedArg,
+    rightVar: IRInstructionTypedArg,
     outputVar?: IRVariable,
   ) {
     super(IROpcode.ICMP, operator, leftVar, rightVar, outputVar, 'icmp');

--- a/packages/compiler-pico-c/src/frontend/ir/instructions/IRInstruction.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/instructions/IRInstruction.ts
@@ -1,9 +1,9 @@
 import { IsPrintable } from '@compiler/core/interfaces';
 import { IROpcode } from '../constants';
-import { IRInstructionVarArg, IRVariable } from '../variables';
+import { IRInstructionArg, IRVariable } from '../variables';
 
 export type IRInstructionArgs = {
-  input: IRInstructionVarArg[];
+  input: IRInstructionArg[];
   output?: IRVariable;
 };
 

--- a/packages/compiler-pico-c/src/frontend/ir/instructions/IRLabelOffsetInstruction.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/instructions/IRLabelOffsetInstruction.ts
@@ -1,9 +1,7 @@
-import chalk from 'chalk';
-
-import { IsLabeledInstruction, IsOutputInstruction } from '../interfaces';
+import { IsOutputInstruction } from '../interfaces';
 import { IROpcode } from '../constants';
 import { IRInstruction, IRInstructionArgs } from './IRInstruction';
-import { IRVariable } from '../variables';
+import { IRLabel, IRVariable } from '../variables';
 
 export function isIRLabelOffsetInstruction(
   instruction: IRInstruction,
@@ -20,15 +18,12 @@ export class IRLabelOffsetInstruction
   extends IRInstruction
   implements IsOutputInstruction
 {
-  constructor(
-    readonly labelInstruction: IsLabeledInstruction,
-    readonly outputVar: IRVariable,
-  ) {
+  constructor(readonly label: IRLabel, readonly outputVar: IRVariable) {
     super(IROpcode.LABEL_OFFSET);
   }
 
   override ofArgs({ output = this.outputVar }: IRInstructionArgs) {
-    return new IRLabelOffsetInstruction(this.labelInstruction, output);
+    return new IRLabelOffsetInstruction(this.label, output);
   }
 
   override getArgs(): IRInstructionArgs {
@@ -41,10 +36,8 @@ export class IRLabelOffsetInstruction
   }
 
   override getDisplayName(): string {
-    const { labelInstruction, outputVar } = this;
+    const { label, outputVar } = this;
 
-    return `${outputVar.getDisplayName()} = ${chalk.yellowBright(
-      'label-offset',
-    )} ${labelInstruction.name}`;
+    return `${outputVar.getDisplayName()} = ${label.getDisplayName()}`;
   }
 }

--- a/packages/compiler-pico-c/src/frontend/ir/instructions/IRLoadInstruction.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/instructions/IRLoadInstruction.ts
@@ -12,7 +12,10 @@ export function isIRLoadInstruction(
 }
 
 /**
- * Instruction that loads variable from mem
+ * Instruction loads memory address pointed by `inputVar`.
+ * Instead of `assign` it performs:
+ *  1. Fetch address (or reuse if exists in any register)
+ *  2. Fetch data at specified address
  */
 export class IRLoadInstruction
   extends IRInstruction

--- a/packages/compiler-pico-c/src/frontend/ir/instructions/IRLoadInstruction.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/instructions/IRLoadInstruction.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import { IsOutputInstruction } from '../interfaces';
 import { IROpcode } from '../constants';
 import { IRInstruction, IRInstructionArgs } from './IRInstruction';
-import { IRInstructionVarArg, IRVariable } from '../variables';
+import { IRInstructionTypedArg, IRVariable } from '../variables';
 
 export function isIRLoadInstruction(
   instruction: IRInstruction,
@@ -19,7 +19,7 @@ export class IRLoadInstruction
   implements IsOutputInstruction
 {
   constructor(
-    readonly inputVar: IRInstructionVarArg,
+    readonly inputVar: IRInstructionTypedArg,
     readonly outputVar: IRVariable,
     readonly offset: number = 0,
   ) {

--- a/packages/compiler-pico-c/src/frontend/ir/instructions/IRMathInstruction.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/instructions/IRMathInstruction.ts
@@ -5,7 +5,7 @@ import { TokenType } from '@compiler/lexer/shared';
 import { IROpcode } from '../constants';
 import { IROpInstruction } from './IROpInstruction';
 import { IRInstruction, IRInstructionArgs } from './IRInstruction';
-import { IRInstructionVarArg, IRVariable } from '../variables';
+import { IRInstructionTypedArg, IRVariable } from '../variables';
 
 export function isIRMathInstruction(
   instruction: IRInstruction,
@@ -19,8 +19,8 @@ export function isIRMathInstruction(
 export class IRMathInstruction extends IROpInstruction<CMathOperator> {
   constructor(
     operator: CMathOperator,
-    leftVar: IRInstructionVarArg,
-    rightVar: IRInstructionVarArg,
+    leftVar: IRInstructionTypedArg,
+    rightVar: IRInstructionTypedArg,
     outputVar?: IRVariable,
   ) {
     super(IROpcode.MATH, operator, leftVar, rightVar, outputVar);

--- a/packages/compiler-pico-c/src/frontend/ir/instructions/IROpInstruction.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/instructions/IROpInstruction.ts
@@ -6,7 +6,7 @@ import { IROpcode } from '../constants';
 import { IRInstruction, IRInstructionArgs } from './IRInstruction';
 import {
   IRConstant,
-  IRInstructionVarArg,
+  IRInstructionTypedArg,
   IRVariable,
   isIRConstant,
   isIRVariable,
@@ -22,8 +22,8 @@ export class IROpInstruction<O>
   constructor(
     opcode: IROpcode,
     readonly operator: O,
-    readonly leftVar: IRInstructionVarArg,
-    readonly rightVar: IRInstructionVarArg,
+    readonly leftVar: IRInstructionTypedArg,
+    readonly rightVar: IRInstructionTypedArg,
     readonly outputVar: IRVariable = null,
     readonly serializerPrefix: string = null,
   ) {

--- a/packages/compiler-pico-c/src/frontend/ir/instructions/IRRetInstruction.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/instructions/IRRetInstruction.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import * as R from 'ramda';
 
 import { IROpcode } from '../constants';
-import { IRInstructionVarArg } from '../variables';
+import { IRInstructionTypedArg } from '../variables';
 import { IRInstruction, IRInstructionArgs } from './IRInstruction';
 
 export function isIRRetInstruction(
@@ -15,7 +15,7 @@ export function isIRRetInstruction(
  * IR return instruction
  */
 export class IRRetInstruction extends IRInstruction {
-  constructor(readonly value?: IRInstructionVarArg) {
+  constructor(readonly value?: IRInstructionTypedArg) {
     super(IROpcode.RET);
   }
 
@@ -24,7 +24,7 @@ export class IRRetInstruction extends IRInstruction {
   }
 
   override ofArgs({ input = [this.value] }: IRInstructionArgs) {
-    return new IRRetInstruction(input[0]);
+    return new IRRetInstruction(<IRInstructionTypedArg>input[0]);
   }
 
   override getArgs(): IRInstructionArgs {

--- a/packages/compiler-pico-c/src/frontend/ir/instructions/IRStoreInstruction.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/instructions/IRStoreInstruction.ts
@@ -5,7 +5,7 @@ import { IsOutputInstruction } from '../interfaces';
 
 import { IROpcode } from '../constants';
 import { IRInstruction, IRInstructionArgs } from './IRInstruction';
-import { IRInstructionVarArg, IRVariable } from '../variables';
+import { IRInstructionTypedArg, IRVariable } from '../variables';
 
 export function isIRStoreInstruction(
   instruction: IRInstruction,
@@ -21,7 +21,7 @@ export class IRStoreInstruction
   implements IsOutputInstruction
 {
   constructor(
-    readonly value: IRInstructionVarArg,
+    readonly value: IRInstructionTypedArg,
     readonly outputVar: IRVariable,
     readonly offset: number = 0,
   ) {

--- a/packages/compiler-pico-c/src/frontend/ir/instructions/IRStoreInstruction.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/instructions/IRStoreInstruction.ts
@@ -14,7 +14,10 @@ export function isIRStoreInstruction(
 }
 
 /**
- * Instruction that saves variable to mem
+ * Instead of `load` it performs only:
+ *  1. Fetch address or reg
+ *
+ * It does not perform loading memory that can be specified by reg.
  */
 export class IRStoreInstruction
   extends IRInstruction

--- a/packages/compiler-pico-c/src/frontend/ir/optimizer/block/optimizeInstructionsList.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/optimizer/block/optimizeInstructionsList.ts
@@ -2,6 +2,7 @@ import { compose } from 'ramda';
 import { IRInstruction } from '../../instructions';
 import {
   concatConstantStoreInstruction,
+  dropConstantLabelOffsetsArgs,
   dropDeadStoreInstructions,
   dropInstructionsWithOrphanOutputs,
   dropNopMathInstructions,
@@ -17,8 +18,8 @@ type OptimizerConfig = {
 };
 
 const optimizeFlow = compose(
-  concatConstantStoreInstruction,
   dropInstructionsWithOrphanOutputs,
+  concatConstantStoreInstruction,
   foldAddressOffsetsInstructions,
   dropRedundantLabelInstructions,
   dropDeadStoreInstructions,
@@ -26,6 +27,7 @@ const optimizeFlow = compose(
   dropRedundantAddressInstructions,
   dropNopMathInstructions,
   flipMathInstructionsOperands,
+  dropConstantLabelOffsetsArgs,
 );
 
 export function optimizeInstructionsList(

--- a/packages/compiler-pico-c/src/frontend/ir/optimizer/block/phases/dropConstantLabelOffsetsArgs.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/optimizer/block/phases/dropConstantLabelOffsetsArgs.ts
@@ -1,0 +1,48 @@
+import {
+  IRInstruction,
+  isIRCallInstruction,
+  isIRLabelOffsetInstruction,
+} from '../../../instructions';
+import { IRLabel, isIRVariable } from '../../../variables';
+
+/**
+ * Replaces labels that are constants in instructions args.
+ *
+ * @example
+ *  Transforms:
+ *
+ *  %t{0}: void sum(int, int)*2B = label-offset sum
+ *  call %t{0}: void sum(int, int)*2B :: (%4: char1B, %4: char1B)
+ *
+ *  To:
+ *
+ *  call label-offset sum: void sum(int, int)*2B :: (%4: char1B, %4: char1B)
+ */
+export function dropConstantLabelOffsetsArgs(instructions: IRInstruction[]) {
+  const newInstructions = [...instructions];
+  const constantOffsets: Record<string, IRLabel> = {};
+
+  for (let i = 0; i < instructions.length; ++i) {
+    const instruction = instructions[i];
+
+    // store label and treat it initially as constant
+    if (isIRLabelOffsetInstruction(instruction)) {
+      constantOffsets[instruction.outputVar.name] = instruction.label;
+      continue;
+    }
+
+    // replace it is using constant offset load
+    if (
+      isIRCallInstruction(instruction) &&
+      isIRVariable(instruction.fnPtr) &&
+      constantOffsets[instruction.fnPtr.name]
+    ) {
+      newInstructions[i] = instruction.ofFnPtr(
+        constantOffsets[instruction.fnPtr.name],
+      );
+      continue;
+    }
+  }
+
+  return newInstructions;
+}

--- a/packages/compiler-pico-c/src/frontend/ir/optimizer/block/phases/dropInstructionsWithOrphanOutputs.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/optimizer/block/phases/dropInstructionsWithOrphanOutputs.ts
@@ -1,11 +1,12 @@
 import {
   IRInstruction,
+  isIRLabelOffsetInstruction,
   isIRLeaInstruction,
   isIRMathInstruction,
 } from '../../../instructions';
 
 import { isOutputInstruction } from '../../../interfaces';
-import { isIRVariable } from '../../../variables';
+import { isIRLabel, isIRVariable } from '../../../variables';
 
 type InstructionOutputUsageInfo = {
   instruction: IRInstruction;
@@ -50,7 +51,7 @@ export function dropInstructionsWithOrphanOutputs(
 
     // track usage
     for (const input of instruction.getArgs().input) {
-      if (!isIRVariable(input)) {
+      if (!isIRVariable(input) && !isIRLabel(input)) {
         continue;
       }
 
@@ -65,7 +66,11 @@ export function dropInstructionsWithOrphanOutputs(
       continue;
     }
 
-    if (isIRMathInstruction(instruction) || isIRLeaInstruction(instruction)) {
+    if (
+      isIRMathInstruction(instruction) ||
+      isIRLeaInstruction(instruction) ||
+      isIRLabelOffsetInstruction(instruction)
+    ) {
       newInstructions.splice(newInstructions.indexOf(instruction), 1);
     }
   }

--- a/packages/compiler-pico-c/src/frontend/ir/optimizer/block/phases/dropNopMathInstructions.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/optimizer/block/phases/dropNopMathInstructions.ts
@@ -1,6 +1,6 @@
 import { TokenType } from '@compiler/lexer/shared';
 import { IRInstruction, isIRMathInstruction } from '../../../instructions';
-import { IRInstructionVarArg } from '../../../variables';
+import { IRInstructionTypedArg } from '../../../variables';
 import { dropConstantInstructionArgs } from '../utils';
 
 /**
@@ -12,7 +12,7 @@ import { dropConstantInstructionArgs } from '../utils';
  */
 export function dropNopMathInstructions(instructions: IRInstruction[]) {
   const newInstructions = [...instructions];
-  const replaceArgs: Record<string, IRInstructionVarArg> = {};
+  const replaceArgs: Record<string, IRInstructionTypedArg> = {};
   let needSecondPass = false;
 
   for (let i = 0; i < newInstructions.length; ++i) {

--- a/packages/compiler-pico-c/src/frontend/ir/optimizer/block/phases/dropRedundantAddressInstructions.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/optimizer/block/phases/dropRedundantAddressInstructions.ts
@@ -1,4 +1,4 @@
-import { isIROutputInstruction } from '../../../guards';
+import { isIRBranchInstruction, isIROutputInstruction } from '../../../guards';
 import { dropConstantInstructionArgs } from '../utils/dropConstantInstructionArgs';
 
 import { IRVariable } from '../../../variables';
@@ -13,12 +13,20 @@ export function dropRedundantAddressInstructions(
 ) {
   let hasCache = false;
 
-  const cachedInputs: { [inputVar: string]: IRVariable } = {};
-  const replacedOutputs: { [outputVar: string]: IRVariable } = {};
+  let cachedInputs: { [inputVar: string]: IRVariable } = {};
+  let replacedOutputs: { [outputVar: string]: IRVariable } = {};
   const newInstructions = [...instructions];
 
   for (let i = 0; i < newInstructions.length; ) {
     const instruction = newInstructions[i];
+
+    if (isIRBranchInstruction(instruction)) {
+      replacedOutputs = {};
+      cachedInputs = {};
+      hasCache = false;
+      ++i;
+      continue;
+    }
 
     if (isIROutputInstruction(instruction)) {
       let cacheKey: string = null;

--- a/packages/compiler-pico-c/src/frontend/ir/optimizer/block/phases/dropRedundantAddressInstructions.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/optimizer/block/phases/dropRedundantAddressInstructions.ts
@@ -26,7 +26,7 @@ export function dropRedundantAddressInstructions(
       if (isIRLeaInstruction(instruction)) {
         ({ name: cacheKey } = instruction.inputVar);
       } else if (isIRLabelOffsetInstruction(instruction)) {
-        cacheKey = instruction.labelInstruction.name;
+        cacheKey = instruction.label.name;
       }
 
       if (cacheKey) {

--- a/packages/compiler-pico-c/src/frontend/ir/optimizer/block/phases/index.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/optimizer/block/phases/index.ts
@@ -1,4 +1,5 @@
 export * from './concatConstantStoreInstructions';
+export * from './dropConstantLabelOffsetsArgs';
 export * from './dropDeadStoreInstructions';
 export * from './dropInstructionsWithOrphanOutputs';
 export * from './dropNopMathInstructions';

--- a/packages/compiler-pico-c/src/frontend/ir/optimizer/block/utils/dropConstantInstructionArgs.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/optimizer/block/utils/dropConstantInstructionArgs.ts
@@ -1,8 +1,8 @@
 import { IRInstruction } from '../../../instructions';
-import { IRInstructionVarArg, isIRVariable } from '../../../variables';
+import { IRInstructionTypedArg, isIRVariable } from '../../../variables';
 
 export function dropConstantInstructionArgs(
-  constantArgs: Record<string, IRInstructionVarArg>,
+  constantArgs: Record<string, IRInstructionTypedArg>,
   instruction: IRInstruction,
 ) {
   let { input, output } = instruction.getArgs();

--- a/packages/compiler-pico-c/src/frontend/ir/utils/getBiggerIRArg.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/utils/getBiggerIRArg.ts
@@ -1,4 +1,6 @@
-import { IRInstructionVarArg } from '../variables';
+import { IRInstructionTypedArg } from '../variables';
 
-export const getBiggerIRArg = <T extends IRInstructionVarArg>(a: T, b: T): T =>
-  a.type.getByteSize() > b.type.getByteSize() ? a : b;
+export const getBiggerIRArg = <T extends IRInstructionTypedArg>(
+  a: T,
+  b: T,
+): T => (a.type.getByteSize() > b.type.getByteSize() ? a : b);

--- a/packages/compiler-pico-c/src/frontend/ir/utils/getSmallerIRArg.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/utils/getSmallerIRArg.ts
@@ -1,4 +1,6 @@
-import { IRInstructionVarArg } from '../variables';
+import { IRInstructionTypedArg } from '../variables';
 
-export const getSmallerIRArg = <T extends IRInstructionVarArg>(a: T, b: T): T =>
-  a.type.getByteSize() < b.type.getByteSize() ? a : b;
+export const getSmallerIRArg = <T extends IRInstructionTypedArg>(
+  a: T,
+  b: T,
+): T => (a.type.getByteSize() < b.type.getByteSize() ? a : b);

--- a/packages/compiler-pico-c/src/frontend/ir/variables/IRInstructionArg.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/variables/IRInstructionArg.ts
@@ -1,0 +1,4 @@
+import { IRInstructionTypedArg } from './IRInstructionTypedArg';
+import { IRLabel } from './IRLabel';
+
+export type IRInstructionArg = IRInstructionTypedArg | IRLabel;

--- a/packages/compiler-pico-c/src/frontend/ir/variables/IRInstructionTypedArg.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/variables/IRInstructionTypedArg.ts
@@ -1,4 +1,4 @@
 import { IRConstant } from './IRConstant';
 import { IRVariable } from './IRVariable';
 
-export type IRInstructionVarArg = IRVariable | IRConstant;
+export type IRInstructionTypedArg = IRVariable | IRConstant;

--- a/packages/compiler-pico-c/src/frontend/ir/variables/IRLabel.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/variables/IRLabel.ts
@@ -1,0 +1,31 @@
+import chalk from 'chalk';
+
+import { IsPrintable } from '@compiler/core/interfaces';
+import { Identity } from '@compiler/core/monads';
+
+export function isIRLabel(obj: any): obj is IRLabel {
+  return !!obj?.value?.name;
+}
+
+export type IRLabelDescriptor = {
+  name: string;
+};
+
+export class IRLabel
+  extends Identity<IRLabelDescriptor>
+  implements IsPrintable
+{
+  static ofName(name: string) {
+    return new IRLabel({
+      name,
+    });
+  }
+
+  get name() {
+    return this.value.name;
+  }
+
+  getDisplayName(): string {
+    return `${chalk.yellowBright('label-offset')} ${this.name}`;
+  }
+}

--- a/packages/compiler-pico-c/src/frontend/ir/variables/index.ts
+++ b/packages/compiler-pico-c/src/frontend/ir/variables/index.ts
@@ -1,4 +1,6 @@
 export * from './IRConstant';
-export * from './IRInstructionVarArg';
+export * from './IRInstructionArg';
+export * from './IRInstructionTypedArg';
+export * from './IRLabel';
 export * from './IRVariable';
 export * from './constants';

--- a/packages/compiler-pico-c/src/frontend/parser/grammar/matchers/expressions/primaryExpression.ts
+++ b/packages/compiler-pico-c/src/frontend/parser/grammar/matchers/expressions/primaryExpression.ts
@@ -70,7 +70,7 @@ export function primaryExpression(grammar: CGrammar): ASTCPrimaryExpression {
         NodeLocation.fromTokenLoc(literal.loc),
         null,
         null,
-        `${literal.text}\0`,
+        literal.text,
       );
     },
 

--- a/packages/compiler-pico-c/src/frontend/parser/grammar/matchers/expressions/primaryExpression.ts
+++ b/packages/compiler-pico-c/src/frontend/parser/grammar/matchers/expressions/primaryExpression.ts
@@ -65,12 +65,12 @@ export function primaryExpression(grammar: CGrammar): ASTCPrimaryExpression {
         );
       }
 
-      // handle "a"
+      // handle "a" and append \0 NULL byte character at the end
       return new ASTCPrimaryExpression(
         NodeLocation.fromTokenLoc(literal.loc),
         null,
         null,
-        literal.text,
+        `${literal.text}\0`,
       );
     },
 

--- a/packages/compiler-pico-c/tests/analyze/functions.test.ts
+++ b/packages/compiler-pico-c/tests/analyze/functions.test.ts
@@ -150,10 +150,10 @@ describe('Function typecheck', () => {
     `).not.toHaveCompilerError();
   });
 
-  test.skip('assign function return to variable does not throw error', () => {
+  test('assign function return to variable does not throw error', () => {
     expect(/* cpp */ `
       int sum(void) { return 2; }
       int main() { int acc = sum(); }
-    `).toHaveCompilerError();
+    `).not.toHaveCompilerError();
   });
 });

--- a/packages/compiler-pico-c/tests/analyze/functions.test.ts
+++ b/packages/compiler-pico-c/tests/analyze/functions.test.ts
@@ -141,10 +141,19 @@ describe('Function typecheck', () => {
     );
   });
 
+  test('can return value from void and does not crash', () => {
+    expect(/* cpp */ `
+      void sum(int a, int b) {
+        int k = a + b;
+        return k;
+      }
+    `).not.toHaveCompilerError();
+  });
+
   test.skip('assign function return to variable does not throw error', () => {
     expect(/* cpp */ `
       int sum(void) { return 2; }
       int main() { int acc = sum(); }
-    `).not.toHaveCompilerError();
+    `).toHaveCompilerError();
   });
 });

--- a/packages/compiler-pico-c/tests/ir/declarations/array.test.ts
+++ b/packages/compiler-pico-c/tests/ir/declarations/array.test.ts
@@ -120,18 +120,18 @@ describe('Arrays declarations IR', () => {
     });
 
     test('should string as pointer to label', () => {
-      expect(/* cpp */ `void main() { const char* str = "Hello world!"; }`)
-        .toCompiledIRBeEqual(/* ruby */ `
+      expect(/* cpp */ `
+        void main() { const char* str = "Hello world!"; }
+      `).toCompiledIRBeEqual(/* ruby */ `
         # --- Block main ---
         def main():
-          str{0}: const char**2B = alloca const char*2B
-          %t{0}: const char*2B = lea c{0}: const char[12]12B
-          *(str{0}: const char**2B) = store %t{0}: const char*2B
-          ret
-          end-def
-
+        str{0}: const char**2B = alloca const char*2B
+        %t{0}: const char*2B = lea c{0}: const char[13]13B
+        *(str{0}: const char**2B) = store %t{0}: const char*2B
+        ret
+        end-def
         # --- Block Data ---
-          c{0}: const char[12]12B = const { 72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 33 }
+        c{0}: const char[13]13B = const { 72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 33, 0 }
       `);
     });
 

--- a/packages/compiler-pico-c/tests/ir/declarations/array.test.ts
+++ b/packages/compiler-pico-c/tests/ir/declarations/array.test.ts
@@ -147,20 +147,21 @@ describe('Arrays declarations IR', () => {
           struct Vec2 vec[] = { of_vector(), of_vector() };
         }
       `).toCompiledIRBeEqual(/* ruby */ `
-        # --- Block of_vector ---
-        def of_vector(%out{0}: struct Vec2**2B):
-          vec{0}: struct Vec2*2B = load %out{0}: struct Vec2**2B
-          *(vec{0}: struct Vec2*2B) = store %0: int2B
-          *(vec{0}: struct Vec2*2B + %6) = store %0: int2B
+          # --- Block of_vector ---
+          def of_vector(%out{0}: struct Vec2*2B):
+          %t{1}: struct Vec2*2B = assign %out{0}: struct Vec2*2B
+          *(%t{1}: struct Vec2*2B) = store %0: int2B
+          *(%t{1}: struct Vec2*2B + %6) = store %0: int2B
           ret
           end-def
           # --- Block main ---
           def main():
           vec{1}: struct Vec2[2]*2B = alloca struct Vec2[2]16B
-          %t{2}: struct Vec2[2]**2B = lea vec{1}: struct Vec2[2]*2B
-          call label-offset of_vector :: (%t{2}: struct Vec2[2]**2B)
-          %t{5}: int*2B = %t{2}: struct Vec2[2]**2B plus %8: int2B
-          call label-offset of_vector :: (%t{5}: int*2B)
+          %t{3}: struct Vec2[2]**2B = lea vec{1}: struct Vec2[2]*2B
+          call label-offset of_vector :: (%t{3}: struct Vec2[2]**2B)
+          %t{5}: int*2B = lea vec{1}: struct Vec2[2]*2B
+          %t{6}: int*2B = %t{5}: int*2B plus %8: int2B
+          call label-offset of_vector :: (%t{6}: int*2B)
           ret
           end-def
       `);

--- a/packages/compiler-pico-c/tests/ir/declarations/array.test.ts
+++ b/packages/compiler-pico-c/tests/ir/declarations/array.test.ts
@@ -154,14 +154,13 @@ describe('Arrays declarations IR', () => {
           *(vec{0}: struct Vec2*2B + %6) = store %0: int2B
           ret
           end-def
-        # --- Block main ---
-        def main():
+          # --- Block main ---
+          def main():
           vec{1}: struct Vec2[2]*2B = alloca struct Vec2[2]16B
-          %t{1}: struct Vec2 of_vector()*2B = label-offset of_vector
           %t{2}: struct Vec2[2]**2B = lea vec{1}: struct Vec2[2]*2B
-          call %t{1}: struct Vec2 of_vector()*2B :: (%t{2}: struct Vec2[2]**2B)
+          call label-offset of_vector :: (%t{2}: struct Vec2[2]**2B)
           %t{5}: int*2B = %t{2}: struct Vec2[2]**2B plus %8: int2B
-          call %t{1}: struct Vec2 of_vector()*2B :: (%t{5}: int*2B)
+          call label-offset of_vector :: (%t{5}: int*2B)
           ret
           end-def
       `);

--- a/packages/compiler-pico-c/tests/ir/statements/assignment.test.ts
+++ b/packages/compiler-pico-c/tests/ir/statements/assignment.test.ts
@@ -209,7 +209,7 @@ describe('Assignment IR', () => {
           sum{0}: int*2B = alloca int2B
           %t{1}: const int*2B = load array{0}: const int**2B
           %t{2}: const int*2B = %t{1}: const int*2B plus %6: int2B
-          %t{3}: const int[4]8B = load %t{2}: const int*2B
+          %t{3}: const int2B = load %t{2}: const int*2B
           %t{5}: const int2B = %t{3}: const int2B plus %12: char1B
           *(sum{0}: int*2B) = store %t{5}: const int2B
           ret
@@ -259,13 +259,11 @@ describe('Assignment IR', () => {
           sum{0}: int*2B = alloca int2B
           %t{0}: struct Vec2*2B = lea vec{0}: struct Vec2[2]*2B
           %t{1}: struct Vec2*2B = %t{0}: struct Vec2*2B plus %4: int2B
-          %t{2}: struct Vec2*2B = lea %t{1}: struct Vec2*2B
-          %t{3}: int2B = load %t{2}: struct Vec2*2B
-          %t{5}: struct Vec2*2B = lea %t{4}: struct Vec2*2B
-          %t{6}: struct Vec2*2B = %t{5}: struct Vec2*2B plus %2: int2B
-          %t{7}: int2B = load %t{6}: struct Vec2*2B
-          %t{8}: struct Vec24B = %t{3}: struct Vec24B plus %t{7}: struct Vec24B
-          *(sum{0}: int*2B) = store %t{8}: struct Vec24B
+          %t{2}: int2B = load %t{1}: struct Vec2*2B
+          %t{4}: struct Vec2*2B = %t{0}: struct Vec2*2B plus %2: int2B
+          %t{5}: int2B = load %t{4}: struct Vec2*2B
+          %t{6}: int2B = %t{2}: int2B plus %t{5}: int2B
+          *(sum{0}: int*2B) = store %t{6}: int2B
           ret
           end-def
       `);
@@ -519,7 +517,7 @@ describe('Assignment IR', () => {
           %t{3}: struct Vec2*2B = load ptr{0}: struct Vec2**2B
           %t{4}: struct Vec2*2B = %t{3}: struct Vec2*2B plus %2: int2B
           %t{5}: int2B = load %t{4}: struct Vec2*2B
-          *(d{0}: int*2B) = store %t{5}: struct Vec24B
+          *(d{0}: int*2B) = store %t{5}: int2B
           ret
           end-def
       `);

--- a/packages/compiler-pico-c/tests/ir/statements/functions.test.ts
+++ b/packages/compiler-pico-c/tests/ir/statements/functions.test.ts
@@ -15,8 +15,7 @@ describe('Functions IR', () => {
         end-def
         # --- Block main ---
         def main():
-        %t{3}: int sum(int, int)*2B = label-offset sum
-        %t{4}: int2B = call %t{3}: int sum(int, int)*2B :: (%1: char1B, %2: char1B)
+        %t{4}: int2B = call label-offset sum :: (%1: char1B, %2: char1B)
         ret
         end-def
     `);
@@ -42,8 +41,7 @@ describe('Functions IR', () => {
         end-def
         # --- Block main ---
         def main():
-        %t{4}: int sum(int, int)*2B = label-offset sum
-        %t{5}: int2B = call %t{4}: int sum(int, int)*2B :: (%1: char1B, %2: char1B)
+        %t{5}: int2B = call label-offset sum :: (%1: char1B, %2: char1B)
         ret
         end-def
     `);
@@ -67,8 +65,7 @@ describe('Functions IR', () => {
         end-def
         # --- Block main ---
         def main():
-        %t{1}: struct Vec2 sum()*2B = label-offset sum
-        %t{2}: struct Vec22B = call %t{1}: struct Vec2 sum()*2B :: ()
+        %t{2}: struct Vec22B = call label-offset sum :: ()
         ret
         end-def
     `);
@@ -86,17 +83,16 @@ describe('Functions IR', () => {
       }
     `).toCompiledIRBeEqual(/* ruby */ `
       # --- Block sum ---
-        def sum(%out{0}: struct Vec2**2B):
+      def sum(%out{0}: struct Vec2**2B):
         out{0}: struct Vec2*2B = load %out{0}: struct Vec2**2B
         *(out{0}: struct Vec2*2B) = store %6: int2B
         ret
         end-def
         # --- Block main ---
         def main():
-        %t{1}: struct Vec2 sum()*2B = label-offset sum
         %t{2}: struct Vec24B = alloca struct Vec24B
         %t{3}: struct Vec2*2B = lea %t{2}: struct Vec24B
-        call %t{1}: struct Vec2 sum()*2B :: (%t{3}: struct Vec2*2B)
+        call label-offset sum :: (%t{3}: struct Vec2*2B)
         ret
         end-def
     `);
@@ -119,8 +115,7 @@ describe('Functions IR', () => {
         # --- Block main ---
         def main():
         out{0}: int*2B = alloca int2B
-        %t{3}: int sum(int, int)*2B = label-offset sum
-        %t{4}: int2B = call %t{3}: int sum(int, int)*2B :: (%1: char1B, %2: char1B)
+        %t{4}: int2B = call label-offset sum :: (%1: char1B, %2: char1B)
         %t{5}: int2B = %t{4}: int2B plus %3: char1B
         *(out{0}: int*2B) = store %t{5}: int2B
         ret
@@ -211,19 +206,18 @@ describe('Functions IR', () => {
     `).toCompiledIRBeEqual(/* ruby */ `
       # --- Block print ---
       def print(str{0}: const char**2B):
-        ret
-        end-def
+      ret
+      end-def
       # --- Block main ---
       def main():
-        %t{0}: void print(const char*)*2B = label-offset print
-        %t{1}: const char**2B = alloca const char*2B
-        %t{2}: const char*2B = lea c{0}: const char[12]12B
-        *(%t{1}: const char**2B) = store %t{2}: const char*2B
-        call %t{0}: void print(const char*)*2B :: (%t{1}: const char**2B)
-        ret
-        end-def
+      %t{1}: const char**2B = alloca const char*2B
+      %t{2}: const char*2B = lea c{0}: const char[12]12B
+      *(%t{1}: const char**2B) = store %t{2}: const char*2B
+      call label-offset print :: (%t{1}: const char**2B)
+      ret
+      end-def
       # --- Block Data ---
-        c{0}: const char[12]12B = const { 104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 33 }
+      c{0}: const char[12]12B = const { 104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 33 }
     `);
   });
 

--- a/packages/compiler-pico-c/tests/ir/statements/functions.test.ts
+++ b/packages/compiler-pico-c/tests/ir/statements/functions.test.ts
@@ -262,4 +262,31 @@ describe('Functions IR', () => {
         end-def
     `);
   });
+
+  test('call with string literal', () => {
+    expect(/* cpp*/ `
+      void printf(const char* str) {}
+      int main() {
+        printf("Hello");
+      }
+    `).toCompiledIRBeEqual(/* ruby */ `
+      # --- Block printf ---
+      def printf(str{0}: const char**2B):
+        ret
+        end-def
+
+
+      # --- Block main ---
+      def main(): [ret: int2B]
+        %t{1}: const char**2B = alloca const char*2B
+        %t{2}: const char*2B = lea c{0}: const char[5]5B
+        *(%t{1}: const char**2B) = store %t{2}: const char*2B
+        call label-offset printf :: (%t{1}: const char**2B)
+        ret
+        end-def
+
+      # --- Block Data ---
+        c{0}: const char[5]5B = const { 72, 101, 108, 108, 111 }
+    `);
+  });
 });

--- a/packages/compiler-pico-c/tests/ir/statements/functions.test.ts
+++ b/packages/compiler-pico-c/tests/ir/statements/functions.test.ts
@@ -83,16 +83,16 @@ describe('Functions IR', () => {
       }
     `).toCompiledIRBeEqual(/* ruby */ `
       # --- Block sum ---
-      def sum(%out{0}: struct Vec2**2B):
-        out{0}: struct Vec2*2B = load %out{0}: struct Vec2**2B
-        *(out{0}: struct Vec2*2B) = store %6: int2B
+      def sum(%out{0}: struct Vec2*2B):
+        %t{1}: struct Vec2*2B = assign %out{0}: struct Vec2*2B
+        *(%t{1}: struct Vec2*2B) = store %6: int2B
         ret
         end-def
         # --- Block main ---
         def main():
-        %t{2}: struct Vec24B = alloca struct Vec24B
-        %t{3}: struct Vec2*2B = lea %t{2}: struct Vec24B
-        call label-offset sum :: (%t{3}: struct Vec2*2B)
+        %t{3}: struct Vec2*2B = alloca struct Vec24B
+        %t{4}: struct Vec2*2B = lea %t{3}: struct Vec2*2B
+        call label-offset sum :: (%t{4}: struct Vec2*2B)
         ret
         end-def
     `);
@@ -173,25 +173,25 @@ describe('Functions IR', () => {
         struct Vec2 vec = (*ptr + 1)(1, 2);
       }
     `).toCompiledIRBeEqual(/* ruby */ `
-      # --- Block of_vec ---
-      def of_vec(x{0}: int*2B, y{0}: int*2B, %out{0}: struct Vec2**2B):
-        v{0}: struct Vec2*2B = load %out{0}: struct Vec2**2B
+        # --- Block of_vec ---
+        def of_vec(x{0}: int*2B, y{0}: int*2B, %out{0}: struct Vec2*2B):
+        %t{3}: struct Vec2*2B = assign %out{0}: struct Vec2*2B
         %t{0}: int2B = load x{0}: int*2B
-        *(v{0}: struct Vec2*2B) = store %t{0}: int2B
+        *(%t{3}: struct Vec2*2B) = store %t{0}: int2B
         %t{1}: int2B = load y{0}: int*2B
-        *(v{0}: struct Vec2*2B + %2) = store %t{1}: int2B
+        *(%t{3}: struct Vec2*2B + %2) = store %t{1}: int2B
         ret
         end-def
         # --- Block main ---
         def main(): [ret: int2B]
         ptr{0}: struct Vec2(int, int)**2B = alloca struct Vec2(int, int)*2B
-        %t{3}: struct Vec2 of_vec(int, int)*2B = label-offset of_vec
-        *(ptr{0}: struct Vec2(int, int)**2B) = store %t{3}: struct Vec2 of_vec(int, int)*2B
+        %t{4}: struct Vec2 of_vec(int, int)*2B = label-offset of_vec
+        *(ptr{0}: struct Vec2(int, int)**2B) = store %t{4}: struct Vec2 of_vec(int, int)*2B
         vec{0}: struct Vec2*2B = alloca struct Vec24B
-        %t{4}: struct Vec2(int, int)*2B = load ptr{0}: struct Vec2(int, int)**2B
-        %t{5}: struct Vec2(int, int)*2B = %t{4}: struct Vec2(int, int)*2B plus %1: char1B
-        %t{6}: struct Vec2**2B = lea vec{0}: struct Vec2*2B
-        call %t{5}: struct Vec2(int, int)*2B :: (%1: char1B, %2: char1B, %t{6}: struct Vec2**2B)
+        %t{5}: struct Vec2(int, int)*2B = load ptr{0}: struct Vec2(int, int)**2B
+        %t{6}: struct Vec2(int, int)*2B = %t{5}: struct Vec2(int, int)*2B plus %1: char1B
+        %t{7}: struct Vec2**2B = lea vec{0}: struct Vec2*2B
+        call %t{6}: struct Vec2(int, int)*2B :: (%1: char1B, %2: char1B, %t{7}: struct Vec2**2B)
         ret
         end-def
     `);

--- a/packages/compiler-pico-c/tests/ir/statements/functions.test.ts
+++ b/packages/compiler-pico-c/tests/ir/statements/functions.test.ts
@@ -211,13 +211,13 @@ describe('Functions IR', () => {
       # --- Block main ---
       def main():
       %t{1}: const char**2B = alloca const char*2B
-      %t{2}: const char*2B = lea c{0}: const char[12]12B
+      %t{2}: const char*2B = lea c{0}: const char[13]13B
       *(%t{1}: const char**2B) = store %t{2}: const char*2B
       call label-offset print :: (%t{1}: const char**2B)
       ret
       end-def
       # --- Block Data ---
-      c{0}: const char[12]12B = const { 104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 33 }
+      c{0}: const char[13]13B = const { 104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 33, 0 }
     `);
   });
 
@@ -270,23 +270,20 @@ describe('Functions IR', () => {
         printf("Hello");
       }
     `).toCompiledIRBeEqual(/* ruby */ `
-      # --- Block printf ---
-      def printf(str{0}: const char**2B):
+        # --- Block printf ---
+        def printf(str{0}: const char**2B):
         ret
         end-def
-
-
-      # --- Block main ---
-      def main(): [ret: int2B]
+        # --- Block main ---
+        def main(): [ret: int2B]
         %t{1}: const char**2B = alloca const char*2B
-        %t{2}: const char*2B = lea c{0}: const char[5]5B
+        %t{2}: const char*2B = lea c{0}: const char[6]6B
         *(%t{1}: const char**2B) = store %t{2}: const char*2B
         call label-offset printf :: (%t{1}: const char**2B)
         ret
         end-def
-
-      # --- Block Data ---
-        c{0}: const char[5]5B = const { 72, 101, 108, 108, 111 }
+        # --- Block Data ---
+        c{0}: const char[6]6B = const { 72, 101, 108, 108, 111, 0 }
     `);
   });
 });

--- a/packages/compiler-pico-c/tests/ir/statements/functions.test.ts
+++ b/packages/compiler-pico-c/tests/ir/statements/functions.test.ts
@@ -233,4 +233,33 @@ describe('Functions IR', () => {
         end-def
     `);
   });
+
+  test('should not return primitive variable from function with void return type', () => {
+    expect(/* cpp*/ `
+      void sum() {
+        int k = 2;
+        return k;
+      }
+    `).toCompiledIRBeEqual(/* ruby */ `
+      # --- Block sum ---
+      def sum():
+        k{0}: int*2B = alloca int2B
+        *(k{0}: int*2B) = store %2: int2B
+        ret
+        end-def
+    `);
+  });
+
+  test('should not return constants from function with void return type', () => {
+    expect(/* cpp*/ `
+      void sum() {
+        return 2;
+      }
+    `).toCompiledIRBeEqual(/* ruby */ `
+      # --- Block sum ---
+      def sum():
+        ret
+        end-def
+    `);
+  });
 });

--- a/packages/compiler-pico-c/tests/ir/statements/increment.test.ts
+++ b/packages/compiler-pico-c/tests/ir/statements/increment.test.ts
@@ -127,12 +127,10 @@ describe('Increment stmt IR', () => {
           *(point{0}: struct Point[2]*2B + %2) = store %6: int2B
           *(point{0}: struct Point[2]*2B + %24) = store %2: int2B
           %t{0}: struct Point*2B = lea point{0}: struct Point[2]*2B
-          %t{1}: struct Point*2B = %t{0}: struct Point*2B plus %24: int2B
-          %t{2}: struct Point*2B = lea %t{1}: struct Point*2B
-          %t{4}: struct Point*2B = %t{2}: struct Point*2B plus %8: int2B
-          %t{5}: struct Point24B = load %t{4}: struct Point*2B
-          %t{6}: struct Point24B = %t{5}: struct Point24B plus %1: int2B
-          *(point{0}: struct Point[2]*2B + %32) = store %t{6}: struct Point24B
+          %t{3}: struct Point*2B = %t{0}: struct Point*2B plus %32: int2B
+          %t{4}: struct Point24B = load %t{3}: struct Point*2B
+          %t{5}: struct Point24B = %t{4}: struct Point24B plus %1: int2B
+          *(point{0}: struct Point[2]*2B + %32) = store %t{5}: struct Point24B
           ret
           end-def
       `);

--- a/packages/compiler-pico-c/tests/x86-codegen/declarations/initializer.test.ts
+++ b/packages/compiler-pico-c/tests/x86-codegen/declarations/initializer.test.ts
@@ -94,12 +94,13 @@ describe('Variables initialization', () => {
         @@_fn_main:
         push bp
         mov bp, sp
-        mov word [bp - 2], 25928  ; *(letters{0}: int*2B) = store %25928: int2B
-        lea bx, [bp - 2]          ; %t{0}: char*2B = lea letters{0}: char[2]*2B
+        mov word [bp - 3], 25928  ; *(letters{0}: int*2B) = store %25928: int2B
+        mov byte [bp - 1], 0      ; *(letters{0}: char[3]*2B + %2) = store %0: char1B
+        lea bx, [bp - 3]          ; %t{0}: char*2B = lea letters{0}: char[3]*2B
         mov al, [bx]              ; %t{1}: char1B = load %t{0}: char*2B
         add al, 2                 ; %t{2}: char1B = %t{1}: char1B plus %2: char1B
         movzx cx, al
-        mov word [bp - 4], cx     ; *(a{0}: int*2B) = store %t{2}: char1B
+        mov word [bp - 5], cx     ; *(a{0}: int*2B) = store %t{2}: char1B
         pop bp
         ret
       `);
@@ -238,9 +239,11 @@ describe('Variables initialization', () => {
         @@_fn_main:
         push bp
         mov bp, sp
-        mov word [bp - 2], 72     ; *(letters1{0}: const char**2B) = store %72: const char*2B
+        mov bx, @@_c_0_           ; %t{0}: const char*2B = lea c{0}: const char[2]2B
+        mov word [bp - 2], bx     ; *(letters1{0}: const char**2B) = store %t{0}: const char*2B
         pop bp
         ret
+        @@_c_0_: db 72, 0
       `);
     });
 
@@ -257,18 +260,17 @@ describe('Variables initialization', () => {
         @@_fn_main:
         push bp
         mov bp, sp
-        mov bx, @@_c_0_           ; %t{0}: const char*2B = lea c{0}: const char[4]4B
+        mov bx, @@_c_0_           ; %t{0}: const char*2B = lea c{0}: const char[5]5B
         mov word [bp - 2], bx     ; *(letters1{0}: const char**2B) = store %t{0}: const char*2B
-        mov di, @@_c_1_           ; %t{1}: char*2B = lea c{1}: char[5]5B
+        mov di, @@_c_1_           ; %t{1}: char*2B = lea c{1}: char[6]6B
         mov word [bp - 4], di     ; *(letters2{0}: char**2B) = store %t{1}: char*2B
-        mov si, @@_c_2_           ; %t{2}: const char*2B = lea c{2}: const char[11]11B
+        mov si, @@_c_2_           ; %t{2}: const char*2B = lea c{2}: const char[12]12B
         mov word [bp - 6], si     ; *(letters3{0}: const char**2B) = store %t{2}: const char*2B
         pop bp
         ret
-
-        @@_c_0_: db 72, 101, 108, 108
-        @@_c_1_: db 72, 101, 108, 108, 111
-        @@_c_2_: db 72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100
+        @@_c_0_: db 72, 101, 108, 108, 0
+        @@_c_1_: db 72, 101, 108, 108, 111, 0
+        @@_c_2_: db 72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 0
       `);
     });
 
@@ -284,14 +286,14 @@ describe('Variables initialization', () => {
         @@_fn_main:
         push bp
         mov bp, sp
-        mov word [bp - 4], 25928  ; *(letters1{0}: int*2B) = store %25928: int2B
-        mov word [bp - 2], 27756  ; *(letters1{0}: int*2B + %2) = store %27756: int2B
-        mov bx, @@_c_0_           ; %t{0}: const char*2B = lea c{0}: const char[6]6B
-        mov word [bp - 6], bx     ; *(letters2{0}: const char**2B) = store %t{0}: const char*2B
+        mov word [bp - 5], 25928  ; *(letters1{0}: int*2B) = store %25928: int2B
+        mov word [bp - 3], 27756  ; *(letters1{0}: int*2B + %2) = store %27756: int2B
+        mov byte [bp - 1], 0      ; *(letters1{0}: char[5]*2B + %4) = store %0: char1B
+        mov bx, @@_c_0_           ; %t{0}: const char*2B = lea c{0}: const char[7]7B
+        mov word [bp - 7], bx     ; *(letters2{0}: const char**2B) = store %t{0}: const char*2B
         pop bp
         ret
-
-        @@_c_0_: db 72, 101, 108, 108, 111, 33
+        @@_c_0_: db 72, 101, 108, 108, 111, 33, 0
       `);
     });
   });

--- a/packages/compiler-pico-c/tests/x86-codegen/declarations/initializer.test.ts
+++ b/packages/compiler-pico-c/tests/x86-codegen/declarations/initializer.test.ts
@@ -205,6 +205,25 @@ describe('Variables initialization', () => {
         @@_c_0_: db 1, 2, 3, 4, 5
       `);
     });
+
+    test('struct array', () => {
+      expect(/* cpp */ `
+        void main() {
+          struct Vec2 { int x, y; char z; } vec[] = { { .y = 4 }, { .x =  5, .z = 7 }};
+        }
+      `).toCompiledAsmBeEqual(`
+        cpu 386
+        ; def main():
+        @@_fn_main:
+        push bp
+        mov bp, sp
+        mov word [bp - 8], 4      ; *(vec{0}: struct Vec2[2]*2B + %2) = store %4: int2B
+        mov word [bp - 5], 5      ; *(vec{0}: struct Vec2[2]*2B + %5) = store %5: int2B
+        mov byte [bp - 1], 7      ; *(vec{0}: struct Vec2[2]*2B + %9) = store %7: char1B
+        pop bp
+        ret
+      `);
+    });
   });
 
   describe('Strings initialization', () => {

--- a/packages/compiler-pico-c/tests/x86-codegen/statements/assign.test.ts
+++ b/packages/compiler-pico-c/tests/x86-codegen/statements/assign.test.ts
@@ -16,16 +16,17 @@ describe('Variable assign', () => {
         @@_fn_main:
         push bp
         mov bp, sp
-        mov word [bp - 2], 25928  ; *(letters{0}: int*2B) = store %25928: int2B
-        mov word [bp - 4], 0      ; *(a{0}: int*2B) = store %0: int2B
-        lea bx, [bp - 2]          ; %t{0}: char*2B = lea letters{0}: char[2]*2B
+        mov word [bp - 3], 25928  ; *(letters{0}: int*2B) = store %25928: int2B
+        mov byte [bp - 1], 0      ; *(letters{0}: char[3]*2B + %2) = store %0: char1B
+        mov word [bp - 5], 0      ; *(a{0}: int*2B) = store %0: int2B
+        lea bx, [bp - 3]          ; %t{0}: char*2B = lea letters{0}: char[3]*2B
         mov al, [bx]              ; %t{1}: char1B = load %t{0}: char*2B
         movzx cx, al
         imul cx, 2                ; %t{2}: char1B = %t{1}: char1B mul %2: char1B
-        mov al, [bp - 4]
+        mov al, [bp - 5]
         add al, cl                ; %t{4}: char1B = %t{3}: char1B plus %t{2}: char1B
         movzx dx, al
-        mov word [bp - 4], dx     ; *(a{0}: int*2B) = store %t{4}: char1B
+        mov word [bp - 5], dx     ; *(a{0}: int*2B) = store %t{4}: char1B
         pop bp
         ret
       `);

--- a/packages/compiler-pico-c/tests/x86-codegen/statements/assign.test.ts
+++ b/packages/compiler-pico-c/tests/x86-codegen/statements/assign.test.ts
@@ -53,6 +53,28 @@ describe('Variable assign', () => {
           a = a + 5;
         }
       `).toCompiledAsmBeEqual(`
+        cpu 386
+        ; def sum():
+        @@_fn_sum:
+        push bp
+        mov bp, sp
+        pop bp
+        ret
+
+        ; def main():
+        @@_fn_main:
+        push bp
+        mov bp, sp
+        mov word [bp - 2], 2      ; *(a{0}: int*2B) = store %2: int2B
+        mov ax, [bp - 2]
+        add ax, 6                 ; %t{1}: int2B = %t{0}: int2B plus %6: char1B
+        mov word [bp - 2], ax     ; *(a{0}: int*2B) = store %t{1}: int2B
+        call @@_fn_sum
+        mov bx, [bp - 2]
+        add bx, 5                 ; %t{4}: int2B = %t{3}: int2B plus %5: char1B
+        mov word [bp - 2], bx     ; *(a{0}: int*2B) = store %t{4}: int2B
+        pop bp
+        ret
       `);
     });
   });

--- a/packages/compiler-pico-c/tests/x86-codegen/statements/assign.test.ts
+++ b/packages/compiler-pico-c/tests/x86-codegen/statements/assign.test.ts
@@ -30,6 +30,31 @@ describe('Variable assign', () => {
         ret
       `);
     });
+
+    test('compiler reuses variable that is already placed in reg', () => {
+      expect(/* cpp */ `
+        void main() {
+          int a = 2;
+          a = a + 6;
+          // sum(4, 4);
+          a = a + 5;
+        }
+      `).toCompiledAsmBeEqual(`
+      `);
+    });
+
+    test('compiler does not reuse variable if branch is between statements', () => {
+      expect(/* cpp */ `
+        void sum() {}
+        void main() {
+          int a = 2;
+          a = a + 6;
+          sum();
+          a = a + 5;
+        }
+      `).toCompiledAsmBeEqual(`
+      `);
+    });
   });
 
   describe('Assign to array item', () => {

--- a/packages/compiler-pico-c/tests/x86-codegen/statements/call.test.ts
+++ b/packages/compiler-pico-c/tests/x86-codegen/statements/call.test.ts
@@ -1,0 +1,130 @@
+import '../utils';
+
+describe('Function call', () => {
+  describe('Primitive types', () => {
+    test('call void function', () => {
+      expect(/* cpp */ `
+        void test() {
+          int k = 2;
+        }
+        void main() {
+          int a = 4;
+          int ks = a + 7;
+          test();
+          int k = a + 10;
+        }
+      `).toCompiledAsmBeEqual(`
+        cpu 386
+        ; def test():
+        @@_fn_test:
+        push bp
+        mov bp, sp
+        mov word [bp - 2], 2      ; *(k{0}: int*2B) = store %2: int2B
+        pop bp
+        ret
+
+        ; def main():
+        @@_fn_main:
+        push bp
+        mov bp, sp
+        mov word [bp - 2], 4      ; *(a{0}: int*2B) = store %4: int2B
+        mov ax, [bp - 2]
+        add ax, 7                 ; %t{1}: int2B = %t{0}: int2B plus %7: char1B
+        mov word [bp - 4], ax     ; *(ks{0}: int*2B) = store %t{1}: int2B
+        call @@_fn_test
+        mov bx, [bp - 2]
+        add bx, 10                ; %t{4}: int2B = %t{3}: int2B plus %10: char1B
+        mov word [bp - 6], bx     ; *(k{1}: int*2B) = store %t{4}: int2B
+        pop bp
+        ret
+      `);
+    });
+
+    test('cleanup extra arguments passed to function', () => {
+      expect(/* cpp */ `
+        void test() {}
+        void main() {
+          test(3, 4, 5);
+        }
+      `).toCompiledAsmBeEqual(`
+        cpu 386
+        ; def test():
+        @@_fn_test:
+        push bp
+        mov bp, sp
+        pop bp
+        ret
+
+        ; def main():
+        @@_fn_main:
+        push bp
+        mov bp, sp
+        push 5
+        push 4
+        push 3
+        call @@_fn_test
+        add sp, 6
+        pop bp
+        ret
+      `);
+    });
+
+    test('returned value from void type is not present', () => {
+      expect(/* cpp */ `
+        void test() {
+          return 2;
+        }
+        void main() {
+          int k = 2;
+          return k;
+        }
+      `).toCompiledAsmBeEqual(`
+        cpu 386
+        ; def test():
+        @@_fn_test:
+        push bp
+        mov bp, sp
+        pop bp
+        ret
+
+        ; def main():
+        @@_fn_main:
+        push bp
+        mov bp, sp
+        mov word [bp - 2], 2      ; *(k{0}: int*2B) = store %2: int2B
+        pop bp
+        ret
+      `);
+    });
+
+    test('return value is stored in reg', () => {
+      expect(/* cpp */ `
+        int sum(int a, int b) { return a + b; }
+        int main() { int acc = sum(1, 2) + 4; }
+      `).toCompiledAsmBeEqual(`
+        cpu 386
+        ; def sum(a{0}: int*2B, b{0}: int*2B): [ret: int2B]
+        @@_fn_sum:
+        push bp
+        mov bp, sp
+        mov ax, [bp + 4]
+        add ax, word [bp + 2]     ; %t{2}: int2B = %t{0}: int2B plus %t{1}: int2B
+        pop bp
+        ret 4
+
+        ; def main(): [ret: int2B]
+        @@_fn_main:
+        push bp
+        mov bp, sp
+        push 2
+        push 1
+        call @@_fn_sum
+        add ax, 4                 ; %t{5}: int2B = %t{4}: int2B plus %4: char1B
+        mov word [bp - 2], ax     ; *(acc{0}: int*2B) = store %t{5}: int2B
+        pop bp
+        ; missing return
+        ret
+      `);
+    });
+  });
+});

--- a/packages/compiler-pico-c/tests/x86-codegen/statements/call.test.ts
+++ b/packages/compiler-pico-c/tests/x86-codegen/statements/call.test.ts
@@ -172,19 +172,17 @@ describe('Function call', () => {
         mov bp, sp
         pop bp
         ret 2
-
         ; def main(): [ret: int2B]
         @@_fn_main:
         push bp
         mov bp, sp
-        mov bx, @@_c_0_           ; %t{2}: const char*2B = lea c{0}: const char[5]5B
+        mov bx, @@_c_0_           ; %t{2}: const char*2B = lea c{0}: const char[6]6B
         mov word [bp - 2], bx     ; *(%t{1}: const char**2B) = store %t{2}: const char*2B
         push word [bp - 2]
         call @@_fn_printf
         pop bp
         ret
-
-        @@_c_0_: db 72, 101, 108, 108, 111
+        @@_c_0_: db 72, 101, 108, 108, 111, 0
       `);
     });
 
@@ -207,9 +205,9 @@ describe('Function call', () => {
         @@_fn_main:
         push bp
         mov bp, sp
-        mov bx, @@_c_0_           ; %t{0}: const char*2B = lea c{0}: const char[12]12B
+        mov bx, @@_c_0_           ; %t{0}: const char*2B = lea c{0}: const char[13]13B
         mov word [bp - 2], bx     ; *(str{1}: const char**2B) = store %t{0}: const char*2B
-        mov di, @@_c_1_           ; %t{3}: const char*2B = lea c{1}: const char[5]5B
+        mov di, @@_c_1_           ; %t{3}: const char*2B = lea c{1}: const char[6]6B
         mov word [bp - 4], di     ; *(%t{2}: const char**2B) = store %t{3}: const char*2B
         mov si, [bp - 2]          ; %t{4}: const char*2B = load str{1}: const char**2B
         push si
@@ -217,8 +215,8 @@ describe('Function call', () => {
         call @@_fn_printf
         pop bp
         ret
-        @@_c_0_: db 72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 33
-        @@_c_1_: db 72, 101, 108, 108, 111
+        @@_c_0_: db 72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 33, 0
+        @@_c_1_: db 72, 101, 108, 108, 111, 0
       `);
     });
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,39 +2,9 @@ import 'source-map-support/register';
 import { ccompiler, CCompilerOutput } from '@compiler/pico-c';
 
 ccompiler(/* cpp */ `
-  // todo: letters[0] should be truncated
-  // huge issue, truncating type in IR!
-  // void main() {
-  //   char letters[] = "Hello world";
-
-  //   char b = letters[0];
-  //   int a = letters[0] * 2;
-  // }
-
-  // todo: Optimize
-  // add bx, 32                ; %t{3}: int*2B = %t{0}: int*2B plus %32: int2B
-  // mov ax, [bx]              ; %t{4}: int2B = load %t{3}: int*2B
-  // struct Point {
-  //   int x, y;
-  //   int dupa[10];
-  //   char c;
-  // };
-
-  // void main() {
-  //   struct Point point[] = { { .y = 6 }, { .x = 2 } };
-  //   point[1].dupa[2]++;
-  // }
-
+  void sum(int a, int b) {}
   void main() {
-    char a = 'a';
-
-    if (a > 4) {
-      int k = 0;
-    } else if (a < 5) {
-      int j = 4;
-    } else {
-      int c = 4;
-    }
+    sum(4, 4);
   }
 `).match({
   ok: result => {
@@ -48,10 +18,3 @@ ccompiler(/* cpp */ `
     console.error(error);
   },
 });
-
-/**
- * Optimize to AL:
- *
- * and ax, 0xff
- * mov word [bp - 12], ax    ; *(b{0}: char*2B) = store %t{1}: int2B
- */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,10 +2,17 @@ import 'source-map-support/register';
 import { ccompiler, CCompilerOutput } from '@compiler/pico-c';
 
 ccompiler(/* cpp */ `
-  void printf(const char* str, const char* str2) {}
+  struct Vec2 {
+    int x, y;
+  };
+
+  int sum_vec(struct Vec2 vec, struct Vec2 vec2) {
+    return vec.x + vec.y;
+  }
+
   int main() {
-    const char* str = "Hello world!";
-    printf("Hello", str);
+    struct Vec2 vec = { .x = 1, .y = 3 };
+    sum_vec(vec, vec);
   }
 `).match({
   ok: result => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,13 +2,13 @@ import 'source-map-support/register';
 import { ccompiler, CCompilerOutput } from '@compiler/pico-c';
 
 ccompiler(/* cpp */ `
-    int sum(int a, int b) {
-      return a + b;
-    }
+  int sum(int a, int b) {
+    return a + b;
+  }
 
-    int main() {
-      int acc = sum(1, 2) + 4;
-    }
+  int main() {
+    int acc = sum(1, 2) + 4;
+  }
 `).match({
   ok: result => {
     result.dump();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,13 +6,19 @@ ccompiler(/* cpp */ `
   // sprawdź co ładuje do: int k =0x6; char i = k;
   // mamy little endian!
 
-  struct Vec2 {
-    int x, y;
-  };
-    struct Vec2 of_vec(int x, int y) {
-    struct Vec2 v = { .x = x, .y = y };
-    return v;
+  int strlen(const char* str) {
+    for (int i = 0;;++i) {
+      if (*(str + i) == '0') {
+        return i;
+      }
     }
+
+    return -1;
+  }
+
+  void main() {
+    strlen("Hello world!");
+  }
     // int main() {
     // struct Vec2 out = of_vec(2, 3);
     // out.x = 1;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,9 +2,11 @@ import 'source-map-support/register';
 import { ccompiler, CCompilerOutput } from '@compiler/pico-c';
 
 ccompiler(/* cpp */ `
-  void sum(int a, int b) {}
+  void sum(int a, int b, int c) {
+    int k = a + b + c;
+  }
   void main() {
-    sum(4, 8);
+    sum(1, 2, 3);
   }
 `).match({
   ok: result => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,12 +2,10 @@ import 'source-map-support/register';
 import { ccompiler, CCompilerOutput } from '@compiler/pico-c';
 
 ccompiler(/* cpp */ `
-  int sum(int a, int b) {
-    return a + b;
-  }
-
+  void printf(const char* str, const char* str2) {}
   int main() {
-    int acc = sum(1, 2) + 4;
+    const char* str = "Hello world!";
+    printf("Hello", str);
   }
 `).match({
   ok: result => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,8 +2,13 @@ import 'source-map-support/register';
 import { ccompiler, CCompilerOutput } from '@compiler/pico-c';
 
 ccompiler(/* cpp */ `
-    int sum(void) { return 2; }
-    int main() { int acc = sum(); }
+    int sum(int a, int b) {
+      return a + b;
+    }
+
+    int main() {
+      int acc = sum(1, 2) + 4;
+    }
 `).match({
   ok: result => {
     result.dump();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,12 +2,8 @@ import 'source-map-support/register';
 import { ccompiler, CCompilerOutput } from '@compiler/pico-c';
 
 ccompiler(/* cpp */ `
-  void sum(int a, int b, int c) {
-    int k = a + b + c;
-  }
-  void main() {
-    sum(1, 2, 3);
-  }
+    int sum(void) { return 2; }
+    int main() { int acc = sum(); }
 `).match({
   ok: result => {
     result.dump();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,18 +2,41 @@ import 'source-map-support/register';
 import { ccompiler, CCompilerOutput } from '@compiler/pico-c';
 
 ccompiler(/* cpp */ `
+  // todo:
+  // sprawdź co ładuje do: int k =0x6; char i = k;
+  // mamy little endian!
+
   struct Vec2 {
     int x, y;
   };
+    struct Vec2 of_vec(int x, int y) {
+    struct Vec2 v = { .x = x, .y = y };
+    return v;
+    }
+    // int main() {
+    // struct Vec2 out = of_vec(2, 3);
+    // out.x = 1;
+    // out.y = 7;
+    // }
 
-  int sum_vec(struct Vec2 vec, struct Vec2 vec2) {
-    return vec.x + vec.y;
-  }
+  // struct Vec2 {
+  //   int x, y;
+  // };
 
-  int main() {
-    struct Vec2 vec = { .x = 1, .y = 3 };
-    sum_vec(vec, vec);
-  }
+  // int sum_vec(struct Vec2 vec) {
+  //   return  vec.x + vec.y;
+  // }
+
+  // int main() {
+    // struct Vec2 vec = { .x = 1, .y = 3 };
+    // int k = vec.x;
+    // vec.x = 3;
+    // sum_vec(vec);
+  // }
+  // void main() {
+  //   struct Vec2 vec = { .x = 1, .y = 3 };
+  //   int k = vec.x + vec.y;
+  // }
 `).match({
   ok: result => {
     result.dump();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import { ccompiler, CCompilerOutput } from '@compiler/pico-c';
 ccompiler(/* cpp */ `
   void sum(int a, int b) {}
   void main() {
-    sum(4, 4);
+    sum(4, 8);
   }
 `).match({
   ok: result => {


### PR DESCRIPTION
Compile simple `void` function calls. At this moment we don't need to return anything. Example:

```c
  void sum(int a, int b) {}
  void main() {
    sum(4, 4);
  }
```

currently, our IR code looks like this:

```ruby
# --- Block sum ---
def sum(a{0}: int*2B, b{0}: int*2B):
  ret
  end-def


# --- Block main ---
def main():
  %t{0}: void sum(int, int)*2B = label-offset sum
  call %t{0}: void sum(int, int)*2B :: (%4: char1B, %4: char1B)
  ret
  end-def
```